### PR TITLE
Keeping pinned notes to the top while merging repositories.

### DIFF
--- a/src/SilentNotes.Shared/Models/NoteListModel.cs
+++ b/src/SilentNotes.Shared/Models/NoteListModel.cs
@@ -48,5 +48,20 @@ namespace SilentNotes.Models
         {
             return Find(item => item.Id == id);
         }
+
+        /// <summary>
+        /// Searches for the first note with <see cref="NoteModel.IsPinned"/> is false, and returns
+        /// the zero based index of this note.
+        /// </summary>
+        /// <returns>Returns index of first unpinned note, or -1 id no such note was found.</returns>
+        public int IndexOfFirstUnpinnedNote()
+        {
+            for (int index = 0; index < Count; index++)
+            {
+                if (!this[index].IsPinned)
+                    return index;
+            }
+            return -1;
+        }
     }
 }

--- a/src/SilentNotes.Shared/Workers/NoteRepositoryMerger.cs
+++ b/src/SilentNotes.Shared/Workers/NoteRepositoryMerger.cs
@@ -53,6 +53,7 @@ namespace SilentNotes.Workers
             }
 
             result.RemoveUnusedSafes();
+            BringPinnedToTop(result.Notes);
             return result;
         }
 
@@ -276,6 +277,28 @@ namespace SilentNotes.Workers
                 comparisonResult = Nullable.Compare(metaModifiedAtSelector(item1), metaModifiedAtSelector(item2));
 
             return (comparisonResult >= 0) ? item1 : item2;
+        }
+
+        /// <summary>
+        /// If the order of the remote repository is newer, it usually wins. Though, if a note was
+        /// pinned on the client and went to the top, it should stick there, even if the order of
+        /// the remote repository has precedence.
+        /// </summary>
+        private static void BringPinnedToTop(NoteListModel notes)
+        {
+            int firstUnpinnedIndex = notes.IndexOfFirstUnpinnedNote();
+            if (firstUnpinnedIndex >= 0)
+            {
+                for (int index = firstUnpinnedIndex; index < notes.Count; index++)
+                {
+                    var note = notes[index];
+                    if (note.IsPinned)
+                    {
+                        notes.RemoveAt(index);
+                        notes.Insert(0, note);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Keeping pinned notes to the top while merging repositories.