### PR TITLE
Fixed bug when WebDav server responds with tags without content inste…

### DIFF
--- a/src/Tests/VanillaCloudStorageClientTest/CloudStorageProviders/WebdavCloudStorageClientTest.cs
+++ b/src/Tests/VanillaCloudStorageClientTest/CloudStorageProviders/WebdavCloudStorageClientTest.cs
@@ -183,6 +183,14 @@ namespace VanillaCloudStorageClientTest.CloudStorageProviders
             Assert.AreEqual("unittest.dat", fileNames[0]);
         }
 
+        [Test]
+        public void ParseKoofrNetResponseCorrectly()
+        {
+            List<string> fileNames = WebdavCloudStorageClient.ParseWebdavResponseForFileNames(GetKoofrNetResponse());
+            Assert.AreEqual(2, fileNames.Count);
+            Assert.AreEqual("silentnotes_repository.silentnotes", fileNames[0]);
+            Assert.AreEqual("unittest.dat", fileNames[1]);
+        }
 
         private string GetWebdavFileListResponse()
         {
@@ -523,6 +531,46 @@ namespace VanillaCloudStorageClientTest.CloudStorageProviders
         <D:resourcetype>
           <D:collection />
         </D:resourcetype>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>";
+            using (TextReader rextReader = new StringReader(response))
+            {
+                return XDocument.Load(rextReader);
+            }
+        }
+
+        private XDocument GetKoofrNetResponse()
+        {
+            string response = @"
+<D:multistatus xmlns:D='DAV:'>
+  <D:response>
+    <D:href>/dav/Koofr/SilentNotes</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:resourcetype>
+          <D:collection xmlns:D='DAV:' />
+        </D:resourcetype>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/dav/Koofr/SilentNotes/silentnotes_repository.silentnotes</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:resourcetype></D:resourcetype>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/dav/Koofr/SilentNotes/unittest.dat</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:resourcetype></D:resourcetype>
       </D:prop>
       <D:status>HTTP/1.1 200 OK</D:status>
     </D:propstat>

--- a/src/VanillaCloudStorageClient/CloudStorageProviders/WebdavCloudStorageClient.cs
+++ b/src/VanillaCloudStorageClient/CloudStorageProviders/WebdavCloudStorageClient.cs
@@ -145,7 +145,7 @@ namespace VanillaCloudStorageClient.CloudStorageProviders
                     .FirstOrDefault();
 
                 // Files have an empty resourcetype
-                bool isFile = (resourceTypeElement != null) && (resourceTypeElement.IsEmpty);
+                bool isFile = ExistsAndHasNoChilds(resourceTypeElement);
                 if (isFile)
                 {
                     // Extract the "href" element, it contains the filename
@@ -162,6 +162,17 @@ namespace VanillaCloudStorageClient.CloudStorageProviders
                 }
             }
             return result;
+        }
+
+        /// <summary>
+        /// Checks whether the XElement is either an empty element (self closing), or doesn't have
+        /// any child elements (opening and closing tag without children).
+        /// </summary>
+        /// <param name="element">Xml element to check.</param>
+        /// <returns>True if it is an empty element, otherwise false.</returns>
+        private static bool ExistsAndHasNoChilds(XElement element)
+        {
+            return (element != null) && !element.HasElements;
         }
     }
 }


### PR DESCRIPTION
Responses from a WebDav server usually contain empty (self closing) tags in the file listing, now SilentNotes can handle also tags with no content.