### PR TITLE
Fixed stuck cursor (up/down arrow keys), when cursor is placed inside…

### DIFF
--- a/src/SilentNotes.Shared/Assets/Html/silentnotes.css
+++ b/src/SilentNotes.Shared/Assets/Html/silentnotes.css
@@ -402,8 +402,8 @@ a[data-tooltip]:hover:after {
 	text-align: right !important;
 	vertical-align: top;
 }
-.note-viewer li p {
-    display: inline-block;
+.note-viewer li>p:first-child {
+    display: inline;
 }
 
 .note-viewer pre {


### PR DESCRIPTION
When cursor was placed inside a list, the up/down keys didn't change to the previous/next item. This problem was fixed, while still hiding the <p> tag contained in the <li> tag.
