### PR TITLE
Delay listening to editor events, until the note is loaded completely.

### DIFF
--- a/src/SilentNotes.Android/Resources/Resource.Designer.cs
+++ b/src/SilentNotes.Android/Resources/Resource.Designer.cs
@@ -14,7 +14,7 @@ namespace SilentNotes.Android
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.2.0.155")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.0.0.73")]
 	public partial class Resource
 	{
 		

--- a/src/SilentNotes.Shared/Controllers/NoteController.cs
+++ b/src/SilentNotes.Shared/Controllers/NoteController.cs
@@ -192,13 +192,14 @@ namespace SilentNotes.Controllers
             // which would have to be interpreted by the WebView and would increase the size of the content.
             // Loading it here avoids this performance issue.
             string escapedContent = _viewModel.GetEscapedUnlockedHtmlContent();
-            StringBuilder script = new StringBuilder(escapedContent.Length + 20);
+            StringBuilder script = new StringBuilder(escapedContent.Length + 90);
             script.Append("initializeNoteContent('");
             script.Append(escapedContent);
             script.Append("');");
             bool isNewNote = _viewModel.SearchableContent.Trim().Length == 0;
             if (isNewNote)
                 script.Append("toggleFormat('heading', 1);");
+            script.Append("startSendingViewModelUpdates();");
             View.ExecuteJavaScript(script.ToString());
         }
     }

--- a/src/SilentNotes.Shared/Views/ChecklistRazorView.cs
+++ b/src/SilentNotes.Shared/Views/ChecklistRazorView.cs
@@ -23,7 +23,7 @@ using SilentNotes.ViewModels;
 #line hidden
 
 
-[System.CodeDom.Compiler.GeneratedCodeAttribute("RazorTemplatePreprocessor", "17.1.0.324")]
+[System.CodeDom.Compiler.GeneratedCodeAttribute("RazorTemplatePreprocessor", "17.3.0.296")]
 public partial class ChecklistRazorView : ChecklistRazorViewBase
 {
 
@@ -230,74 +230,77 @@ WriteLiteral("; }\r\ndiv.dark .detail-view.checklist .ProseMirror p::after { con
 WriteLiteral("; }\r\n\r\n.color-btn { color: black; }\r\n.color-btn.dark { color: white; }\r\n.locked {" +
 "\r\n    position: relative;\r\n    height: 100%;\r\n}\r\n.locked svg {\r\n    fill: rgba(1" +
 "60, 160, 160, 0.4);\r\n}\r\n    </style>\r\n    <script>\r\n        var editor;\r\n       " +
-" var ignoreViewModelUpdate = false;\r\n\r\n        /* Notifies the viewmodel about c" +
-"hanges in the note content. */\r\n        function triggerViewModelUpdate() {\r\n   " +
-"         if (!ignoreViewModelUpdate)\r\n                vuePropertyChanged(\'Unlock" +
-"edHtmlContent\', null);\r\n        }\r\n\r\n        /* Collects all calls to triggerVie" +
-"wModelUpdate() and bundles them to a single call. */\r\n        function bundleVie" +
-"wModelUpdates(delegate) {\r\n            try {\r\n                ignoreViewModelUpd" +
-"ate = true;\r\n                delegate();\r\n            }\r\n            finally {\r\n" +
-"                ignoreViewModelUpdate = false;\r\n            }\r\n            trigg" +
-"erViewModelUpdate();\r\n        }\r\n\r\n        function getSearchDialogElement() {\r\n" +
-"            return document.getElementById(\'search-dialog\');\r\n        }\r\n\r\n     " +
-"   function getTagsElement() {\r\n            return document.getElementById(\'tags" +
-"\');\r\n        }\r\n\r\n        function toggleFormat(formatName, formatParameter) {\r\n" +
-"            ProseMirrorBundle.toggleFormat(editor, formatName, formatParameter);" +
-"\r\n            refreshActiveFormatState();\r\n        }\r\n\r\n        function refresh" +
-"ActiveFormatState() {\r\n            vm.Header1Active = ProseMirrorBundle.isFormat" +
-"Active(editor, \'heading\', { level: 1 });\r\n            vm.Header2Active = ProseMi" +
-"rrorBundle.isFormatActive(editor, \'heading\', { level: 2 });\r\n            vm.Head" +
-"er3Active = ProseMirrorBundle.isFormatActive(editor, \'heading\', { level: 3 });\r\n" +
-"            vm.BoldActive = ProseMirrorBundle.isFormatActive(editor, \'bold\');\r\n " +
-"           vm.ItalicActive = ProseMirrorBundle.isFormatActive(editor, \'italic\');" +
-"\r\n            vm.UnderlineActive = ProseMirrorBundle.isFormatActive(editor, \'und" +
-"erline\');\r\n            vm.StrikeActive = ProseMirrorBundle.isFormatActive(editor" +
-", \'strike\');\r\n            vm.CodeActive = ProseMirrorBundle.isFormatActive(edito" +
-"r, \'codeblock\');\r\n            vm.QuoteActive = ProseMirrorBundle.isFormatActive(" +
-"editor, \'blockquote\');\r\n            vm.ListBulletActive = ProseMirrorBundle.isFo" +
-"rmatActive(editor, \'bulletlist\');\r\n            vm.ListOrderedActive = ProseMirro" +
-"rBundle.isFormatActive(editor, \'orderedlist\');\r\n        }\r\n\r\n        function un" +
-"do() {\r\n            editor.commands.undo();\r\n        }\r\n\r\n        function redo(" +
-") {\r\n            editor.commands.redo();\r\n        }\r\n\r\n        function addTag()" +
-" {\r\n            var tagText = getTagsElement().value.trim();\r\n            if (vm" +
-".ShoppingModeActive || tagText === \'\')\r\n                return;\r\n            get" +
-"TagsElement().value = \'\';\r\n            vueCommandExecute(\'AddTagCommand\', tagTex" +
-"t);\r\n        }\r\n\r\n        function deleteTag(e) {\r\n            if (vm.ShoppingMo" +
-"deActive)\r\n                return;\r\n            vueCommandExecute(\'DeleteTagComm" +
-"and\', e.currentTarget.attributes[\'data-tag\'].value);\r\n        }\r\n\r\n        funct" +
-"ion getTagSuggestions() {\r\n            return vm.$data.TagSuggestions.map(functi" +
-"on (item) {\r\n                return { value: item }\r\n            });\r\n        }\r" +
-"\n\r\n        function getNoteHtmlContent() {\r\n            return editor.getHTML();" +
-"\r\n        }\r\n\r\n        // By setting the content after loading the page, we can " +
-"avoid that the content has to be\r\n        // declared statically as javascript a" +
-"nd therefore would occupy memory twice.\r\n        function initializeNoteContent(" +
-"text) {\r\n            try {\r\n                editor.chain().setMeta(\'addToHistory" +
-"\', false).setContent(text).scrollToTop().run();\r\n            }\r\n            catc" +
-"h (ex) {\r\n                editor.setEditable(false);\r\n                document.g" +
-"etElementById(\'myeditor\').textContent = ex.message;\r\n            }\r\n        }\r\n\r" +
-"\n        function isSearchDialogHidden() {\r\n            return getSearchDialogEl" +
-"ement().classList.contains(\'hidden\');\r\n        }\r\n\r\n        function toggleSearc" +
-"hDialog() {\r\n            showSearchDialog(isSearchDialogHidden());\r\n        }\r\n\r" +
-"\n        function showSearchDialog(visible) {\r\n            if (visible) {\r\n     " +
-"           // Open dialog\r\n                var filter = ProseMirrorBundle.getSel" +
-"ectedText(editor);\r\n                if (filter !== null) {\r\n                    " +
-"vm.SearchPattern = filter.trim();\r\n                }\r\n                getSearchD" +
-"ialogElement().classList.remove(\'hidden\');\r\n                document.getElementB" +
-"yId(\'SearchPattern\').focus();\r\n                searchByFilter();\r\n            }\r" +
-"\n            else {\r\n                // Close dialog\r\n                vm.SearchP" +
-"attern = \'\';\r\n                getSearchDialogElement().classList.add(\'hidden\');\r" +
-"\n                searchByFilter();\r\n            }\r\n        }\r\n\r\n        function" +
-" searchByFilter() {\r\n            ProseMirrorBundle.searchAndHighlight(editor, vm" +
-".SearchPattern);\r\n        }\r\n\r\n        function toggleShoppingMode() {\r\n        " +
-"    vm.ShoppingModeActive = !vm.ShoppingModeActive;\r\n            editor.setEdita" +
-"ble(!vm.ShoppingModeActive);\r\n        }\r\n\r\n        function vueLoaded() {\r\n     " +
-"       var editorElement = document.getElementById(\'myeditor\');\r\n            edi" +
-"tor = ProseMirrorBundle.initializeChecklist(editorElement);\r\n            editor." +
-"on(\'selectionUpdate\', function (editor) {\r\n                refreshActiveFormatSt" +
-"ate();\r\n            });\r\n            editor.on(\'update\', function (editor) {\r\n  " +
-"              triggerViewModelUpdate();\r\n            });\r\n            ProseMirro" +
-"rBundle.registerIsShoppingModeActive(function () { return vm.ShoppingModeActive;" +
-" });\r\n\r\n            ");
+" var ignoreViewModelUpdate = true;\r\n\r\n        /* Starts notifying the viewmodel " +
+"about changes. Call it as soon as the content is completely loaded. */\r\n        " +
+"function startSendingViewModelUpdates() {\r\n            ignoreViewModelUpdate = f" +
+"alse;\r\n        }\r\n\r\n        /* Notifies the viewmodel about changes in the note " +
+"content. */\r\n        function triggerViewModelUpdate() {\r\n            if (!ignor" +
+"eViewModelUpdate)\r\n                vuePropertyChanged(\'UnlockedHtmlContent\', nul" +
+"l);\r\n        }\r\n\r\n        /* Collects all calls to triggerViewModelUpdate() and " +
+"bundles them to a single call. */\r\n        function bundleViewModelUpdates(deleg" +
+"ate) {\r\n            try {\r\n                ignoreViewModelUpdate = true;\r\n      " +
+"          delegate();\r\n            }\r\n            finally {\r\n                ign" +
+"oreViewModelUpdate = false;\r\n            }\r\n            triggerViewModelUpdate()" +
+";\r\n        }\r\n\r\n        function getSearchDialogElement() {\r\n            return " +
+"document.getElementById(\'search-dialog\');\r\n        }\r\n\r\n        function getTags" +
+"Element() {\r\n            return document.getElementById(\'tags\');\r\n        }\r\n\r\n " +
+"       function toggleFormat(formatName, formatParameter) {\r\n            ProseMi" +
+"rrorBundle.toggleFormat(editor, formatName, formatParameter);\r\n            refre" +
+"shActiveFormatState();\r\n        }\r\n\r\n        function refreshActiveFormatState()" +
+" {\r\n            vm.Header1Active = ProseMirrorBundle.isFormatActive(editor, \'hea" +
+"ding\', { level: 1 });\r\n            vm.Header2Active = ProseMirrorBundle.isFormat" +
+"Active(editor, \'heading\', { level: 2 });\r\n            vm.Header3Active = ProseMi" +
+"rrorBundle.isFormatActive(editor, \'heading\', { level: 3 });\r\n            vm.Bold" +
+"Active = ProseMirrorBundle.isFormatActive(editor, \'bold\');\r\n            vm.Itali" +
+"cActive = ProseMirrorBundle.isFormatActive(editor, \'italic\');\r\n            vm.Un" +
+"derlineActive = ProseMirrorBundle.isFormatActive(editor, \'underline\');\r\n        " +
+"    vm.StrikeActive = ProseMirrorBundle.isFormatActive(editor, \'strike\');\r\n     " +
+"       vm.CodeActive = ProseMirrorBundle.isFormatActive(editor, \'codeblock\');\r\n " +
+"           vm.QuoteActive = ProseMirrorBundle.isFormatActive(editor, \'blockquote" +
+"\');\r\n            vm.ListBulletActive = ProseMirrorBundle.isFormatActive(editor, " +
+"\'bulletlist\');\r\n            vm.ListOrderedActive = ProseMirrorBundle.isFormatAct" +
+"ive(editor, \'orderedlist\');\r\n        }\r\n\r\n        function undo() {\r\n           " +
+" editor.commands.undo();\r\n        }\r\n\r\n        function redo() {\r\n            ed" +
+"itor.commands.redo();\r\n        }\r\n\r\n        function addTag() {\r\n            var" +
+" tagText = getTagsElement().value.trim();\r\n            if (vm.ShoppingModeActive" +
+" || tagText === \'\')\r\n                return;\r\n            getTagsElement().value" +
+" = \'\';\r\n            vueCommandExecute(\'AddTagCommand\', tagText);\r\n        }\r\n\r\n " +
+"       function deleteTag(e) {\r\n            if (vm.ShoppingModeActive)\r\n        " +
+"        return;\r\n            vueCommandExecute(\'DeleteTagCommand\', e.currentTarg" +
+"et.attributes[\'data-tag\'].value);\r\n        }\r\n\r\n        function getTagSuggestio" +
+"ns() {\r\n            return vm.$data.TagSuggestions.map(function (item) {\r\n      " +
+"          return { value: item }\r\n            });\r\n        }\r\n\r\n        function" +
+" getNoteHtmlContent() {\r\n            return editor.getHTML();\r\n        }\r\n\r\n    " +
+"    // By setting the content after loading the page, we can avoid that the cont" +
+"ent has to be\r\n        // declared statically as javascript and therefore would " +
+"occupy memory twice.\r\n        function initializeNoteContent(text) {\r\n          " +
+"  try {\r\n                editor.chain().setMeta(\'addToHistory\', false).setConten" +
+"t(text).scrollToTop().run();\r\n            }\r\n            catch (ex) {\r\n         " +
+"       editor.setEditable(false);\r\n                document.getElementById(\'myed" +
+"itor\').textContent = ex.message;\r\n            }\r\n        }\r\n\r\n        function i" +
+"sSearchDialogHidden() {\r\n            return getSearchDialogElement().classList.c" +
+"ontains(\'hidden\');\r\n        }\r\n\r\n        function toggleSearchDialog() {\r\n      " +
+"      showSearchDialog(isSearchDialogHidden());\r\n        }\r\n\r\n        function s" +
+"howSearchDialog(visible) {\r\n            if (visible) {\r\n                // Open " +
+"dialog\r\n                var filter = ProseMirrorBundle.getSelectedText(editor);\r" +
+"\n                if (filter !== null) {\r\n                    vm.SearchPattern = " +
+"filter.trim();\r\n                }\r\n                getSearchDialogElement().clas" +
+"sList.remove(\'hidden\');\r\n                document.getElementById(\'SearchPattern\'" +
+").focus();\r\n                searchByFilter();\r\n            }\r\n            else {" +
+"\r\n                // Close dialog\r\n                vm.SearchPattern = \'\';\r\n     " +
+"           getSearchDialogElement().classList.add(\'hidden\');\r\n                se" +
+"archByFilter();\r\n            }\r\n        }\r\n\r\n        function searchByFilter() {" +
+"\r\n            ProseMirrorBundle.searchAndHighlight(editor, vm.SearchPattern);\r\n " +
+"       }\r\n\r\n        function toggleShoppingMode() {\r\n            vm.ShoppingMode" +
+"Active = !vm.ShoppingModeActive;\r\n            editor.setEditable(!vm.ShoppingMod" +
+"eActive);\r\n        }\r\n\r\n        function vueLoaded() {\r\n            var editorEl" +
+"ement = document.getElementById(\'myeditor\');\r\n            editor = ProseMirrorBu" +
+"ndle.initializeChecklist(editorElement);\r\n            editor.on(\'selectionUpdate" +
+"\', function (editor) {\r\n                refreshActiveFormatState();\r\n           " +
+" });\r\n            editor.on(\'update\', function (editor) {\r\n                trigg" +
+"erViewModelUpdate();\r\n            });\r\n            ProseMirrorBundle.registerIsS" +
+"hoppingModeActive(function () { return vm.ShoppingModeActive; });\r\n\r\n           " +
+" ");
 
 WriteLiteral(@"
 
@@ -332,13 +335,13 @@ WriteLiteral(@"
 ");
 
 
-#line 219 "ChecklistRazorView.cshtml"
+#line 224 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 219 "ChecklistRazorView.cshtml"
+#line 224 "ChecklistRazorView.cshtml"
           WriteLiteral(Model.VueDataBindingScript);
 
 #line default
@@ -361,7 +364,7 @@ WriteLiteral(" v-on:click=\"GoBackCommand\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 224 "ChecklistRazorView.cshtml"
+#line 229 "ChecklistRazorView.cshtml"
                                     , Tuple.Create<string,object,bool> ("", Model.Language["back"]
 
 #line default
@@ -371,7 +374,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 224 "ChecklistRazorView.cshtml"
+#line 229 "ChecklistRazorView.cshtml"
                                                                                                       WriteLiteral(Model.Icon["arrow-left"]);
 
 #line default
@@ -379,13 +382,13 @@ WriteLiteral(">");
 WriteLiteral("</button>\r\n\r\n");
 
 
-#line 226 "ChecklistRazorView.cshtml"
+#line 231 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 226 "ChecklistRazorView.cshtml"
+#line 231 "ChecklistRazorView.cshtml"
          if (!Model.IsLocked)
         {
              
@@ -403,7 +406,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 229 "ChecklistRazorView.cshtml"
+#line 234 "ChecklistRazorView.cshtml"
                                                                                                                         , Tuple.Create<string,object,bool> ("", Model.Language["checklist_move_to_top"]
 
 #line default
@@ -413,7 +416,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 229 "ChecklistRazorView.cshtml"
+#line 234 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                            WriteLiteral(Model.Icon["arrow-collapse-up"]);
 
 #line default
@@ -430,7 +433,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 230 "ChecklistRazorView.cshtml"
+#line 235 "ChecklistRazorView.cshtml"
                                                                                                                        , Tuple.Create<string,object,bool> ("", Model.Language["checklist_move_up"]
 
 #line default
@@ -440,7 +443,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 230 "ChecklistRazorView.cshtml"
+#line 235 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                       WriteLiteral(Model.Icon["arrow-up"]);
 
 #line default
@@ -457,7 +460,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 231 "ChecklistRazorView.cshtml"
+#line 236 "ChecklistRazorView.cshtml"
                                                                                                                         , Tuple.Create<string,object,bool> ("", Model.Language["checklist_move_down"]
 
 #line default
@@ -467,7 +470,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 231 "ChecklistRazorView.cshtml"
+#line 236 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                          WriteLiteral(Model.Icon["arrow-down"]);
 
 #line default
@@ -484,7 +487,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 232 "ChecklistRazorView.cshtml"
+#line 237 "ChecklistRazorView.cshtml"
                                                                                                                          , Tuple.Create<string,object,bool> ("", Model.Language["checklist_move_to_bottom"]
 
 #line default
@@ -494,7 +497,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 232 "ChecklistRazorView.cshtml"
+#line 237 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                WriteLiteral(Model.Icon["arrow-collapse-down"]);
 
 #line default
@@ -511,7 +514,7 @@ WriteLiteral(" v-bind:class=\"{ active: ShoppingModeActive }\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 233 "ChecklistRazorView.cshtml"
+#line 238 "ChecklistRazorView.cshtml"
                                                                                                  , Tuple.Create<string,object,bool> ("", Model.Language["note_shopping_mode"]
 
 #line default
@@ -521,7 +524,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 233 "ChecklistRazorView.cshtml"
+#line 238 "ChecklistRazorView.cshtml"
                                                                                                                                                                                  WriteLiteral(Model.Icon["keyboard_off_outline"]);
 
 #line default
@@ -536,7 +539,7 @@ WriteLiteral(" onclick=\"toggleSearchDialog(); return false;\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 234 "ChecklistRazorView.cshtml"
+#line 239 "ChecklistRazorView.cshtml"
                                                    , Tuple.Create<string,object,bool> ("", Model.Language["search"]
 
 #line default
@@ -546,7 +549,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 234 "ChecklistRazorView.cshtml"
+#line 239 "ChecklistRazorView.cshtml"
                                                                                                                        WriteLiteral(Model.Icon["magnify"]);
 
 #line default
@@ -554,7 +557,7 @@ WriteLiteral(">");
 WriteLiteral("</button>\r\n");
 
 
-#line 235 "ChecklistRazorView.cshtml"
+#line 240 "ChecklistRazorView.cshtml"
 
 
 
@@ -579,13 +582,13 @@ WriteLiteral(" aria-expanded=\"false\"");
 WriteLiteral(">\r\n");
 
 
-#line 238 "ChecklistRazorView.cshtml"
+#line 243 "ChecklistRazorView.cshtml"
                     
 
 #line default
 #line hidden
 
-#line 238 "ChecklistRazorView.cshtml"
+#line 243 "ChecklistRazorView.cshtml"
                       WriteLiteral(Model.Icon["dots-vertical"]);
 
 #line default
@@ -608,7 +611,7 @@ WriteLiteral(" onclick=\"bundleViewModelUpdates(function () {ProseMirrorBundle.s
 WriteLiteral(">");
 
 
-#line 241 "ChecklistRazorView.cshtml"
+#line 246 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                     WriteLiteral(Model.Icon["sort-bool-descending-variant"]);
 
 #line default
@@ -616,7 +619,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 241 "ChecklistRazorView.cshtml"
+#line 246 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                                                                           Write(Model.Language["checklist_move_pending_to_top"]);
 
 
@@ -634,7 +637,7 @@ WriteLiteral(" onclick=\"bundleViewModelUpdates(function () {ProseMirrorBundle.s
 WriteLiteral(">");
 
 
-#line 242 "ChecklistRazorView.cshtml"
+#line 247 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                     WriteLiteral(Model.Icon["sort-alphabetical-ascending"]);
 
 #line default
@@ -642,7 +645,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 242 "ChecklistRazorView.cshtml"
+#line 247 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                                                                          Write(Model.Language["checklist_sort_alphabetical"]);
 
 
@@ -664,7 +667,7 @@ WriteLiteral(" onclick=\"bundleViewModelUpdates(function () {ProseMirrorBundle.s
 WriteLiteral(">");
 
 
-#line 244 "ChecklistRazorView.cshtml"
+#line 249 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                     WriteLiteral(Model.Icon["checkbox-multiple-blank-outline"]);
 
 #line default
@@ -672,7 +675,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 244 "ChecklistRazorView.cshtml"
+#line 249 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                                                                              Write(Model.Language["checklist_uncheck_all"]);
 
 
@@ -690,7 +693,7 @@ WriteLiteral(" onclick=\"bundleViewModelUpdates(function () {ProseMirrorBundle.s
 WriteLiteral(">");
 
 
-#line 245 "ChecklistRazorView.cshtml"
+#line 250 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                     WriteLiteral(Model.Icon["check-box-multiple-outline"]);
 
 #line default
@@ -698,7 +701,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 245 "ChecklistRazorView.cshtml"
+#line 250 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                                                                         Write(Model.Language["checklist_check_all"]);
 
 
@@ -716,7 +719,7 @@ WriteLiteral(" onclick=\"bundleViewModelUpdates(function () {ProseMirrorBundle.s
 WriteLiteral(">");
 
 
-#line 246 "ChecklistRazorView.cshtml"
+#line 251 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                         WriteLiteral(Model.Icon["checkbox-blank-off-outline"]);
 
 #line default
@@ -724,7 +727,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 246 "ChecklistRazorView.cshtml"
+#line 251 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                                                                             Write(Model.Language["checklist_disable_all"]);
 
 
@@ -745,7 +748,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'heading\', 1);\"");
 WriteLiteral(">");
 
 
-#line 248 "ChecklistRazorView.cshtml"
+#line 253 "ChecklistRazorView.cshtml"
                                                                                                                                                               WriteLiteral(Model.Icon["format-header-1"]);
 
 #line default
@@ -753,7 +756,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 248 "ChecklistRazorView.cshtml"
+#line 253 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                        Write(Model.Language["note_header1"]);
 
 
@@ -770,7 +773,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'heading\', 2);\"");
 WriteLiteral(">");
 
 
-#line 249 "ChecklistRazorView.cshtml"
+#line 254 "ChecklistRazorView.cshtml"
                                                                                                                                                               WriteLiteral(Model.Icon["format-header-2"]);
 
 #line default
@@ -778,7 +781,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 249 "ChecklistRazorView.cshtml"
+#line 254 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                        Write(Model.Language["note_header2"]);
 
 
@@ -811,7 +814,7 @@ WriteLiteral(" xlink:href=\"#svg-undo\"");
 WriteLiteral(" /></svg> ");
 
 
-#line 251 "ChecklistRazorView.cshtml"
+#line 256 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                  Write(Model.Language["undo"]);
 
 
@@ -840,7 +843,7 @@ WriteLiteral(" xlink:href=\"#svg-redo\"");
 WriteLiteral(" /></svg> ");
 
 
-#line 252 "ChecklistRazorView.cshtml"
+#line 257 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                                  Write(Model.Language["redo"]);
 
 
@@ -859,7 +862,7 @@ WriteLiteral(" data-target=\"#colorPaletteModal\"");
 WriteLiteral(">");
 
 
-#line 253 "ChecklistRazorView.cshtml"
+#line 258 "ChecklistRazorView.cshtml"
                                                                                                                                                       WriteLiteral(Model.Icon["palette"]);
 
 #line default
@@ -867,7 +870,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 253 "ChecklistRazorView.cshtml"
+#line 258 "ChecklistRazorView.cshtml"
                                                                                                                                                                                        Write(Model.Language["note_colors"]);
 
 
@@ -876,13 +879,13 @@ WriteLiteral(" ");
 WriteLiteral("</div>\r\n");
 
 
-#line 254 "ChecklistRazorView.cshtml"
+#line 259 "ChecklistRazorView.cshtml"
                     
 
 #line default
 #line hidden
 
-#line 254 "ChecklistRazorView.cshtml"
+#line 259 "ChecklistRazorView.cshtml"
                      if (Model.CanKeepScreenOn)
                     {
 
@@ -900,7 +903,7 @@ WriteLiteral(" v-on:click=\"KeepScreenOnCommand\"");
 WriteLiteral(">");
 
 
-#line 256 "ChecklistRazorView.cshtml"
+#line 261 "ChecklistRazorView.cshtml"
                                                                                                                                     WriteLiteral(Model.Icon["alarm-plus"]);
 
 #line default
@@ -908,7 +911,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 256 "ChecklistRazorView.cshtml"
+#line 261 "ChecklistRazorView.cshtml"
                                                                                                                                                                         Write(Model.KeepScreenOnTitle);
 
 
@@ -917,7 +920,7 @@ WriteLiteral(" ");
 WriteLiteral("</div>\r\n");
 
 
-#line 257 "ChecklistRazorView.cshtml"
+#line 262 "ChecklistRazorView.cshtml"
                     }
 
 
@@ -934,7 +937,7 @@ WriteLiteral(" v-on:click=\"TogglePinnedCommand\"");
 WriteLiteral(">");
 
 
-#line 258 "ChecklistRazorView.cshtml"
+#line 263 "ChecklistRazorView.cshtml"
                                                                                                                                                     WriteLiteral(Model.Icon["pin"]);
 
 #line default
@@ -942,7 +945,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 258 "ChecklistRazorView.cshtml"
+#line 263 "ChecklistRazorView.cshtml"
                                                                                                                                                                                  Write(Model.Language["note_pin"]);
 
 
@@ -959,7 +962,7 @@ WriteLiteral(" v-on:click=\"ShowInfoCommand\"");
 WriteLiteral(">");
 
 
-#line 259 "ChecklistRazorView.cshtml"
+#line 264 "ChecklistRazorView.cshtml"
                                                                                                                               WriteLiteral(Model.Icon["information"]);
 
 #line default
@@ -967,7 +970,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 259 "ChecklistRazorView.cshtml"
+#line 264 "ChecklistRazorView.cshtml"
                                                                                                                                                                    Write(Model.Language["note_show_info"]);
 
 
@@ -976,13 +979,13 @@ WriteLiteral(" ");
 WriteLiteral("</div>\r\n");
 
 
-#line 260 "ChecklistRazorView.cshtml"
+#line 265 "ChecklistRazorView.cshtml"
                     
 
 #line default
 #line hidden
 
-#line 260 "ChecklistRazorView.cshtml"
+#line 265 "ChecklistRazorView.cshtml"
                      if (Model.ShowManualSynchronization)
                     {
 
@@ -1006,7 +1009,7 @@ WriteLiteral(" v-on:click=\"PushNoteToOnlineStorageCommand\"");
 WriteLiteral(">");
 
 
-#line 263 "ChecklistRazorView.cshtml"
+#line 268 "ChecklistRazorView.cshtml"
                                                                                                                                                  WriteLiteral(Model.Icon["cloud-upload"]);
 
 #line default
@@ -1014,7 +1017,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 263 "ChecklistRazorView.cshtml"
+#line 268 "ChecklistRazorView.cshtml"
                                                                                                                                                                                        Write(Model.Language["note_push_to_server"]);
 
 
@@ -1033,7 +1036,7 @@ WriteLiteral(" v-on:click=\"PullNoteFromOnlineStorageCommand\"");
 WriteLiteral(">");
 
 
-#line 264 "ChecklistRazorView.cshtml"
+#line 269 "ChecklistRazorView.cshtml"
                                                                                                                                                    WriteLiteral(Model.Icon["cloud-download"]);
 
 #line default
@@ -1041,7 +1044,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 264 "ChecklistRazorView.cshtml"
+#line 269 "ChecklistRazorView.cshtml"
                                                                                                                                                                                            Write(Model.Language["note_pull_from_server"]);
 
 
@@ -1050,7 +1053,7 @@ WriteLiteral(" ");
 WriteLiteral("</div>\r\n");
 
 
-#line 265 "ChecklistRazorView.cshtml"
+#line 270 "ChecklistRazorView.cshtml"
                     }
 
 
@@ -1059,7 +1062,7 @@ WriteLiteral("</div>\r\n");
 WriteLiteral("                </div>\r\n            </div>\r\n");
 
 
-#line 268 "ChecklistRazorView.cshtml"
+#line 273 "ChecklistRazorView.cshtml"
         }
 
 
@@ -1076,13 +1079,13 @@ WriteLiteral(" v-bind:style=\"{ backgroundColor: BackgroundColorHex }\"");
 WriteLiteral(">\r\n");
 
 
-#line 272 "ChecklistRazorView.cshtml"
+#line 277 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 272 "ChecklistRazorView.cshtml"
+#line 277 "ChecklistRazorView.cshtml"
          if (Model.IsLocked)
         {
 
@@ -1110,7 +1113,7 @@ WriteLiteral(" xlink:href=\"#svg-lock-outline\"");
 WriteLiteral(" /></svg></span>\r\n");
 
 
-#line 275 "ChecklistRazorView.cshtml"
+#line 280 "ChecklistRazorView.cshtml"
         }
         else
         {
@@ -1128,7 +1131,7 @@ WriteAttribute ("class", " class=\"", "\""
 , Tuple.Create<string,object,bool> ("", "note-viewer", true)
 , Tuple.Create<string,object,bool> (" ", "detail-view", true)
 
-#line 278 "ChecklistRazorView.cshtml"
+#line 283 "ChecklistRazorView.cshtml"
                             , Tuple.Create<string,object,bool> (" ", Model.CssClassNoteType
 
 #line default
@@ -1138,7 +1141,7 @@ WriteAttribute ("class", " class=\"", "\""
 WriteLiteral("></div>\r\n");
 
 
-#line 279 "ChecklistRazorView.cshtml"
+#line 284 "ChecklistRazorView.cshtml"
         }
 
 
@@ -1168,7 +1171,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("placeholder", " placeholder=\'", "\'"
 
-#line 285 "ChecklistRazorView.cshtml"
+#line 290 "ChecklistRazorView.cshtml"
                                                                  , Tuple.Create<string,object,bool> ("", Model.Language["tag_add"]
 
 #line default
@@ -1351,13 +1354,13 @@ WriteLiteral(" class=\"d-flex flex-wrap\"");
 WriteLiteral(">\r\n");
 
 
-#line 315 "ChecklistRazorView.cshtml"
+#line 320 "ChecklistRazorView.cshtml"
                     
 
 #line default
 #line hidden
 
-#line 315 "ChecklistRazorView.cshtml"
+#line 320 "ChecklistRazorView.cshtml"
                      foreach (var backgroundColor in @Model.BackgroundColorsHex)
                     {
 
@@ -1372,7 +1375,7 @@ WriteAttribute ("class", " class=\"", "\""
 , Tuple.Create<string,object,bool> (" ", "justify-content-center", true)
 , Tuple.Create<string,object,bool> (" ", "color-btn", true)
 
-#line 317 "ChecklistRazorView.cshtml"
+#line 322 "ChecklistRazorView.cshtml"
                                                        , Tuple.Create<string,object,bool> (" ", Model.GetDarkClass(backgroundColor)
 
 #line default
@@ -1384,7 +1387,7 @@ WriteLiteral(" data-dismiss=\"modal\"");
 WriteAttribute ("v-on:click", " v-on:click=\"", "\""
 , Tuple.Create<string,object,bool> ("", "BackgroundColorHex=\'", true)
 
-#line 317 "ChecklistRazorView.cshtml"
+#line 322 "ChecklistRazorView.cshtml"
                                                                                                                                                     , Tuple.Create<string,object,bool> ("", backgroundColor
 
 #line default
@@ -1395,7 +1398,7 @@ WriteAttribute ("v-on:click", " v-on:click=\"", "\""
 WriteAttribute ("style", " style=\"", "\""
 , Tuple.Create<string,object,bool> ("", "background-color:", true)
 
-#line 317 "ChecklistRazorView.cshtml"
+#line 322 "ChecklistRazorView.cshtml"
                                                                                                                                                                                                 , Tuple.Create<string,object,bool> (" ", backgroundColor
 
 #line default
@@ -1405,7 +1408,7 @@ WriteAttribute ("style", " style=\"", "\""
 WriteLiteral("><span>Lorem ipsum</span></div>\r\n");
 
 
-#line 318 "ChecklistRazorView.cshtml"
+#line 323 "ChecklistRazorView.cshtml"
                     }
 
 
@@ -1415,13 +1418,13 @@ WriteLiteral("                </div>\r\n            </div>\r\n        </div>\r\n
 "v hidden>\r\n");
 
 
-#line 325 "ChecklistRazorView.cshtml"
+#line 330 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 325 "ChecklistRazorView.cshtml"
+#line 330 "ChecklistRazorView.cshtml"
           WriteLiteral(Model.Icon.LoadIcon("lock-outline", new[] { new KeyValuePair<string, string>("id", "svg-lock-outline") }));
 
 #line default
@@ -1429,13 +1432,13 @@ WriteLiteral("                </div>\r\n            </div>\r\n        </div>\r\n
 WriteLiteral("\r\n");
 
 
-#line 326 "ChecklistRazorView.cshtml"
+#line 331 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 326 "ChecklistRazorView.cshtml"
+#line 331 "ChecklistRazorView.cshtml"
           WriteLiteral(Model.Icon.LoadIcon("delete", new[] { new KeyValuePair<string, string>("id", "svg-delete") }));
 
 #line default
@@ -1443,13 +1446,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 327 "ChecklistRazorView.cshtml"
+#line 332 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 327 "ChecklistRazorView.cshtml"
+#line 332 "ChecklistRazorView.cshtml"
           WriteLiteral(Model.Icon.LoadIcon("close-circle-outline", new[] { new KeyValuePair<string, string>("id", "svg-close-circle-outline") }));
 
 #line default
@@ -1457,13 +1460,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 328 "ChecklistRazorView.cshtml"
+#line 333 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 328 "ChecklistRazorView.cshtml"
+#line 333 "ChecklistRazorView.cshtml"
           WriteLiteral(Model.Icon.LoadIcon("plus", new[] { new KeyValuePair<string, string>("id", "svg-plus") }));
 
 #line default
@@ -1471,13 +1474,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 329 "ChecklistRazorView.cshtml"
+#line 334 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 329 "ChecklistRazorView.cshtml"
+#line 334 "ChecklistRazorView.cshtml"
           WriteLiteral(Model.Icon.LoadIcon("chevron-up", new[] { new KeyValuePair<string, string>("id", "svg-chevron-up") }));
 
 #line default
@@ -1485,13 +1488,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 330 "ChecklistRazorView.cshtml"
+#line 335 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 330 "ChecklistRazorView.cshtml"
+#line 335 "ChecklistRazorView.cshtml"
           WriteLiteral(Model.Icon.LoadIcon("chevron-down", new[] { new KeyValuePair<string, string>("id", "svg-chevron-down") }));
 
 #line default
@@ -1499,13 +1502,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 331 "ChecklistRazorView.cshtml"
+#line 336 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 331 "ChecklistRazorView.cshtml"
+#line 336 "ChecklistRazorView.cshtml"
           WriteLiteral(Model.Icon.LoadIcon("undo", new[] { new KeyValuePair<string, string>("id", "svg-undo") }));
 
 #line default
@@ -1513,13 +1516,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 332 "ChecklistRazorView.cshtml"
+#line 337 "ChecklistRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 332 "ChecklistRazorView.cshtml"
+#line 337 "ChecklistRazorView.cshtml"
           WriteLiteral(Model.Icon.LoadIcon("redo", new[] { new KeyValuePair<string, string>("id", "svg-redo") }));
 
 #line default

--- a/src/SilentNotes.Shared/Views/ChecklistRazorView.cshtml
+++ b/src/SilentNotes.Shared/Views/ChecklistRazorView.cshtml
@@ -47,7 +47,12 @@ div.dark .detail-view.checklist .ProseMirror p::after { content: @{WriteLiteral(
     </style>
     <script>
         var editor;
-        var ignoreViewModelUpdate = false;
+        var ignoreViewModelUpdate = true;
+
+        /* Starts notifying the viewmodel about changes. Call it as soon as the content is completely loaded. */
+        function startSendingViewModelUpdates() {
+            ignoreViewModelUpdate = false;
+        }
 
         /* Notifies the viewmodel about changes in the note content. */
         function triggerViewModelUpdate() {

--- a/src/SilentNotes.Shared/Views/NoteRazorView.cs
+++ b/src/SilentNotes.Shared/Views/NoteRazorView.cs
@@ -23,7 +23,7 @@ using SilentNotes.ViewModels;
 #line hidden
 
 
-[System.CodeDom.Compiler.GeneratedCodeAttribute("RazorTemplatePreprocessor", "17.1.0.324")]
+[System.CodeDom.Compiler.GeneratedCodeAttribute("RazorTemplatePreprocessor", "17.3.0.296")]
 public partial class NoteRazorView : NoteRazorViewBase
 {
 
@@ -166,83 +166,87 @@ WriteLiteral(">\r\nbody { background-color: transparent; }\r\n\r\n.note-viewer {
 WriteLiteral("px !important;\r\n}\r\n.color-btn { color: black; }\r\n.color-btn.dark { color: white; " +
 "}\r\n.locked {\r\n    position: relative;\r\n    height: 100%;\r\n}\r\n.locked svg {\r\n    " +
 "fill: rgba(160, 160, 160, 0.4);\r\n}\r\n    </style>\r\n    <script>\r\n        var edit" +
-"or;\r\n        var linkDialog;\r\n\r\n        /* Notifies the viewmodel about changes " +
-"in the note content. */\r\n        function triggerViewModelUpdate() {\r\n          " +
-"  vuePropertyChanged(\'UnlockedHtmlContent\', null);\r\n        }\r\n\r\n        functio" +
-"n getSearchDialogElement() {\r\n            return document.getElementById(\'search" +
-"-dialog\');\r\n        }\r\n\r\n        function getTagsElement() {\r\n            return" +
-" document.getElementById(\'tags\');\r\n        }\r\n\r\n        function toggleFormat(fo" +
-"rmatName, formatParameter) {\r\n            ProseMirrorBundle.toggleFormat(editor," +
-" formatName, formatParameter);\r\n            refreshActiveFormatState();\r\n       " +
-" }\r\n\r\n        function refreshActiveFormatState() {\r\n            vm.Header1Activ" +
-"e = ProseMirrorBundle.isFormatActive(editor, \'heading\', { level: 1 });\r\n        " +
-"    vm.Header2Active = ProseMirrorBundle.isFormatActive(editor, \'heading\', { lev" +
-"el: 2 });\r\n            vm.Header3Active = ProseMirrorBundle.isFormatActive(edito" +
-"r, \'heading\', { level: 3 });\r\n            vm.BoldActive = ProseMirrorBundle.isFo" +
-"rmatActive(editor, \'bold\');\r\n            vm.ItalicActive = ProseMirrorBundle.isF" +
-"ormatActive(editor, \'italic\');\r\n            vm.UnderlineActive = ProseMirrorBund" +
-"le.isFormatActive(editor, \'underline\');\r\n            vm.StrikeActive = ProseMirr" +
-"orBundle.isFormatActive(editor, \'strike\');\r\n            vm.CodeActive = ProseMir" +
-"rorBundle.isFormatActive(editor, \'codeblock\');\r\n            vm.QuoteActive = Pro" +
-"seMirrorBundle.isFormatActive(editor, \'blockquote\');\r\n            vm.ListBulletA" +
-"ctive = ProseMirrorBundle.isFormatActive(editor, \'bulletlist\');\r\n            vm." +
-"ListOrderedActive = ProseMirrorBundle.isFormatActive(editor, \'orderedlist\');\r\n  " +
-"      }\r\n\r\n        function showLinkDialog() {\r\n            if (vm.ShoppingModeA" +
-"ctive) return;\r\n\r\n            editor.chain().focus().run();\r\n            var sel" +
-"ectedUrl = editor.getAttributes(\'link\').href;\r\n            if (selectedUrl) {\r\n " +
-"               editor.commands.extendMarkRange(\'link\');\r\n                vm.OldL" +
-"inkUrl = selectedUrl;\r\n                vm.NewLinkUrl = selectedUrl;\r\n           " +
-" }\r\n            else {\r\n                var text = ProseMirrorBundle.selectWordA" +
-"tCurrentPosition(editor);\r\n                vm.OldLinkUrl = \'\'; // Consider it as" +
-" modified\r\n                vm.NewLinkUrl = ProseMirrorBundle.makeLinkSuggestion(" +
-"text);\r\n            }\r\n            linkDialog.show();\r\n        }\r\n\r\n        func" +
-"tion linkDialogOpenPressed() {\r\n            location.href = vm.NewLinkUrl;\r\n    " +
-"    }\r\n\r\n        function linkDialogOkPressed() {\r\n            var commandChain " +
-"= editor.chain().focus();\r\n            if (vm.NewLinkUrl != vm.OldLinkUrl) {\r\n  " +
-"              if (vm.NewLinkUrl) {\r\n                    commandChain.extendMarkR" +
-"ange(\'link\').setLink({ href: vm.NewLinkUrl });\r\n                }\r\n             " +
-"   else {\r\n                    commandChain.extendMarkRange(\'link\').unsetLink();" +
-"\r\n                }\r\n            }\r\n            commandChain.run();\r\n           " +
-" linkDialog.hide();\r\n        }\r\n\r\n        function undo() {\r\n            editor." +
-"commands.undo();\r\n        }\r\n\r\n        function redo() {\r\n            editor.com" +
-"mands.redo();\r\n        }\r\n\r\n        function addTag() {\r\n            var tagText" +
-" = getTagsElement().value.trim();\r\n            if (vm.ShoppingModeActive || tagT" +
-"ext === \'\')\r\n                return;\r\n            getTagsElement().value = \'\';\r\n" +
-"            vueCommandExecute(\'AddTagCommand\', tagText);\r\n        }\r\n\r\n        f" +
-"unction deleteTag(e) {\r\n            if (vm.ShoppingModeActive)\r\n                " +
-"return;\r\n            vueCommandExecute(\'DeleteTagCommand\', e.currentTarget.attri" +
-"butes[\'data-tag\'].value);\r\n        }\r\n\r\n        function getTagSuggestions() {\r\n" +
-"            return vm.$data.TagSuggestions.map(function (item) {\r\n              " +
-"  return { value: item }\r\n            });\r\n        }\r\n\r\n        function getNote" +
-"HtmlContent() {\r\n            return editor.getHTML();\r\n        }\r\n\r\n        // B" +
-"y setting the content after loading the page, we can avoid that the content has " +
-"to be\r\n        // declared statically as javascript and therefore would occupy m" +
-"emory twice.\r\n        function initializeNoteContent(text) {\r\n            try {\r" +
-"\n                editor.chain().setMeta(\'addToHistory\', false).setContent(text)." +
-"scrollToTop().run();\r\n            }\r\n            catch (ex) {\r\n                e" +
-"ditor.setEditable(false);\r\n                document.getElementById(\'myeditor\').t" +
-"extContent = ex.message;\r\n            }\r\n        }\r\n\r\n        function isSearchD" +
-"ialogHidden() {\r\n            return getSearchDialogElement().classList.contains(" +
-"\'hidden\');\r\n        }\r\n\r\n        function toggleSearchDialog() {\r\n            sh" +
-"owSearchDialog(isSearchDialogHidden());\r\n        }\r\n\r\n        function showSearc" +
-"hDialog(visible) {\r\n            if (visible) {\r\n                // Open dialog\r\n" +
-"                var filter = ProseMirrorBundle.getSelectedText(editor);\r\n       " +
-"         if (filter !== null) {\r\n                    vm.SearchPattern = filter.t" +
-"rim();\r\n                }\r\n                getSearchDialogElement().classList.re" +
-"move(\'hidden\');\r\n                document.getElementById(\'SearchPattern\').focus(" +
-");\r\n                searchByFilter();\r\n            }\r\n            else {\r\n      " +
-"          // Close dialog\r\n                vm.SearchPattern = \'\';\r\n             " +
-"   getSearchDialogElement().classList.add(\'hidden\');\r\n                searchByFi" +
-"lter();\r\n            }\r\n        }\r\n\r\n        function searchByFilter() {\r\n      " +
-"      ProseMirrorBundle.searchAndHighlight(editor, vm.SearchPattern);\r\n        }" +
-"\r\n\r\n        function toggleShoppingMode() {\r\n            vm.ShoppingModeActive =" +
-" !vm.ShoppingModeActive;\r\n            editor.setEditable(!vm.ShoppingModeActive)" +
-";\r\n        }\r\n\r\n        function vueLoaded() {\r\n            var editorElement = " +
-"document.getElementById(\'myeditor\');\r\n            editor = ProseMirrorBundle.ini" +
-"tializeEditor(editorElement);\r\n            editor.on(\'selectionUpdate\', function" +
-" (editor) {\r\n                refreshActiveFormatState();\r\n            });\r\n     " +
-"       editor.on(\'update\', function (editor) {\r\n                triggerViewModel" +
-"Update();\r\n            });\r\n\r\n            ");
+"or;\r\n        var linkDialog;\r\n        var ignoreViewModelUpdate = true;\r\n\r\n     " +
+"   /* Starts notifying the viewmodel about changes. Call it as soon as the conte" +
+"nt is completely loaded. */\r\n        function startSendingViewModelUpdates() {\r\n" +
+"            ignoreViewModelUpdate = false;\r\n        }\r\n\r\n        /* Notifies the" +
+" viewmodel about changes in the note content. */\r\n        function triggerViewMo" +
+"delUpdate() {\r\n            if (!ignoreViewModelUpdate)\r\n                vuePrope" +
+"rtyChanged(\'UnlockedHtmlContent\', null);\r\n        }\r\n\r\n        function getSearc" +
+"hDialogElement() {\r\n            return document.getElementById(\'search-dialog\');" +
+"\r\n        }\r\n\r\n        function getTagsElement() {\r\n            return document." +
+"getElementById(\'tags\');\r\n        }\r\n\r\n        function toggleFormat(formatName, " +
+"formatParameter) {\r\n            ProseMirrorBundle.toggleFormat(editor, formatNam" +
+"e, formatParameter);\r\n            refreshActiveFormatState();\r\n        }\r\n\r\n    " +
+"    function refreshActiveFormatState() {\r\n            vm.Header1Active = ProseM" +
+"irrorBundle.isFormatActive(editor, \'heading\', { level: 1 });\r\n            vm.Hea" +
+"der2Active = ProseMirrorBundle.isFormatActive(editor, \'heading\', { level: 2 });\r" +
+"\n            vm.Header3Active = ProseMirrorBundle.isFormatActive(editor, \'headin" +
+"g\', { level: 3 });\r\n            vm.BoldActive = ProseMirrorBundle.isFormatActive" +
+"(editor, \'bold\');\r\n            vm.ItalicActive = ProseMirrorBundle.isFormatActiv" +
+"e(editor, \'italic\');\r\n            vm.UnderlineActive = ProseMirrorBundle.isForma" +
+"tActive(editor, \'underline\');\r\n            vm.StrikeActive = ProseMirrorBundle.i" +
+"sFormatActive(editor, \'strike\');\r\n            vm.CodeActive = ProseMirrorBundle." +
+"isFormatActive(editor, \'codeblock\');\r\n            vm.QuoteActive = ProseMirrorBu" +
+"ndle.isFormatActive(editor, \'blockquote\');\r\n            vm.ListBulletActive = Pr" +
+"oseMirrorBundle.isFormatActive(editor, \'bulletlist\');\r\n            vm.ListOrdere" +
+"dActive = ProseMirrorBundle.isFormatActive(editor, \'orderedlist\');\r\n        }\r\n\r" +
+"\n        function showLinkDialog() {\r\n            if (vm.ShoppingModeActive) ret" +
+"urn;\r\n\r\n            editor.chain().focus().run();\r\n            var selectedUrl =" +
+" editor.getAttributes(\'link\').href;\r\n            if (selectedUrl) {\r\n           " +
+"     editor.commands.extendMarkRange(\'link\');\r\n                vm.OldLinkUrl = s" +
+"electedUrl;\r\n                vm.NewLinkUrl = selectedUrl;\r\n            }\r\n      " +
+"      else {\r\n                var text = ProseMirrorBundle.selectWordAtCurrentPo" +
+"sition(editor);\r\n                vm.OldLinkUrl = \'\'; // Consider it as modified\r" +
+"\n                vm.NewLinkUrl = ProseMirrorBundle.makeLinkSuggestion(text);\r\n  " +
+"          }\r\n            linkDialog.show();\r\n        }\r\n\r\n        function linkD" +
+"ialogOpenPressed() {\r\n            location.href = vm.NewLinkUrl;\r\n        }\r\n\r\n " +
+"       function linkDialogOkPressed() {\r\n            var commandChain = editor.c" +
+"hain().focus();\r\n            if (vm.NewLinkUrl != vm.OldLinkUrl) {\r\n            " +
+"    if (vm.NewLinkUrl) {\r\n                    commandChain.extendMarkRange(\'link" +
+"\').setLink({ href: vm.NewLinkUrl });\r\n                }\r\n                else {\r" +
+"\n                    commandChain.extendMarkRange(\'link\').unsetLink();\r\n        " +
+"        }\r\n            }\r\n            commandChain.run();\r\n            linkDialo" +
+"g.hide();\r\n        }\r\n\r\n        function undo() {\r\n            editor.commands.u" +
+"ndo();\r\n        }\r\n\r\n        function redo() {\r\n            editor.commands.redo" +
+"();\r\n        }\r\n\r\n        function addTag() {\r\n            var tagText = getTags" +
+"Element().value.trim();\r\n            if (vm.ShoppingModeActive || tagText === \'\'" +
+")\r\n                return;\r\n            getTagsElement().value = \'\';\r\n          " +
+"  vueCommandExecute(\'AddTagCommand\', tagText);\r\n        }\r\n\r\n        function de" +
+"leteTag(e) {\r\n            if (vm.ShoppingModeActive)\r\n                return;\r\n " +
+"           vueCommandExecute(\'DeleteTagCommand\', e.currentTarget.attributes[\'dat" +
+"a-tag\'].value);\r\n        }\r\n\r\n        function getTagSuggestions() {\r\n          " +
+"  return vm.$data.TagSuggestions.map(function (item) {\r\n                return {" +
+" value: item }\r\n            });\r\n        }\r\n\r\n        function getNoteHtmlConten" +
+"t() {\r\n            return editor.getHTML();\r\n        }\r\n\r\n        // By setting " +
+"the content after loading the page, we can avoid that the content has to be\r\n   " +
+"     // declared statically as javascript and therefore would occupy memory twic" +
+"e.\r\n        function initializeNoteContent(text) {\r\n            try {\r\n         " +
+"       editor.chain().setMeta(\'addToHistory\', false).setContent(text).scrollToTo" +
+"p().run();\r\n            }\r\n            catch (ex) {\r\n                editor.setE" +
+"ditable(false);\r\n                document.getElementById(\'myeditor\').textContent" +
+" = ex.message;\r\n            }\r\n        }\r\n\r\n        function isSearchDialogHidde" +
+"n() {\r\n            return getSearchDialogElement().classList.contains(\'hidden\');" +
+"\r\n        }\r\n\r\n        function toggleSearchDialog() {\r\n            showSearchDi" +
+"alog(isSearchDialogHidden());\r\n        }\r\n\r\n        function showSearchDialog(vi" +
+"sible) {\r\n            if (visible) {\r\n                // Open dialog\r\n          " +
+"      var filter = ProseMirrorBundle.getSelectedText(editor);\r\n                i" +
+"f (filter !== null) {\r\n                    vm.SearchPattern = filter.trim();\r\n  " +
+"              }\r\n                getSearchDialogElement().classList.remove(\'hidd" +
+"en\');\r\n                document.getElementById(\'SearchPattern\').focus();\r\n      " +
+"          searchByFilter();\r\n            }\r\n            else {\r\n                " +
+"// Close dialog\r\n                vm.SearchPattern = \'\';\r\n                getSear" +
+"chDialogElement().classList.add(\'hidden\');\r\n                searchByFilter();\r\n " +
+"           }\r\n        }\r\n\r\n        function searchByFilter() {\r\n            Pros" +
+"eMirrorBundle.searchAndHighlight(editor, vm.SearchPattern);\r\n        }\r\n\r\n      " +
+"  function toggleShoppingMode() {\r\n            vm.ShoppingModeActive = !vm.Shopp" +
+"ingModeActive;\r\n            editor.setEditable(!vm.ShoppingModeActive);\r\n       " +
+" }\r\n\r\n        function vueLoaded() {\r\n            var editorElement = document.g" +
+"etElementById(\'myeditor\');\r\n            editor = ProseMirrorBundle.initializeEdi" +
+"tor(editorElement);\r\n            editor.on(\'selectionUpdate\', function (editor) " +
+"{\r\n                refreshActiveFormatState();\r\n            });\r\n            edi" +
+"tor.on(\'update\', function (editor) {\r\n                triggerViewModelUpdate();\r" +
+"\n            });\r\n\r\n            ");
 
 WriteLiteral("\r\n\r\n            document.addEventListener(\'custom-link-clicked\', function () {\r\n " +
 "               showLinkDialog();\r\n            });\r\n\r\n            var linkDialogE" +
@@ -267,13 +271,13 @@ WriteLiteral("\r\n\r\n            document.addEventListener(\'custom-link-clicke
 "          });\r\n        }\r\n\r\n");
 
 
-#line 245 "NoteRazorView.cshtml"
+#line 252 "NoteRazorView.cshtml"
         
 
 #line default
 #line hidden
 
-#line 245 "NoteRazorView.cshtml"
+#line 252 "NoteRazorView.cshtml"
           WriteLiteral(Model.VueDataBindingScript);
 
 #line default
@@ -296,7 +300,7 @@ WriteLiteral(" v-on:click=\"GoBackCommand\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 251 "NoteRazorView.cshtml"
+#line 258 "NoteRazorView.cshtml"
                                         , Tuple.Create<string,object,bool> ("", Model.Language["back"]
 
 #line default
@@ -306,7 +310,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 251 "NoteRazorView.cshtml"
+#line 258 "NoteRazorView.cshtml"
                                                                                                           WriteLiteral(Model.Icon["arrow-left"]);
 
 #line default
@@ -314,13 +318,13 @@ WriteLiteral(">");
 WriteLiteral("</button>\r\n\r\n");
 
 
-#line 253 "NoteRazorView.cshtml"
+#line 260 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 253 "NoteRazorView.cshtml"
+#line 260 "NoteRazorView.cshtml"
              if (!Model.IsLocked)
             {   
 
@@ -339,7 +343,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 255 "NoteRazorView.cshtml"
+#line 262 "NoteRazorView.cshtml"
                                                                                                                     , Tuple.Create<string,object,bool> ("", Model.Language["note_bold"]
 
 #line default
@@ -349,7 +353,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 255 "NoteRazorView.cshtml"
+#line 262 "NoteRazorView.cshtml"
                                                                                                                                                                                            WriteLiteral(Model.Icon["format-bold"]);
 
 #line default
@@ -368,7 +372,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 256 "NoteRazorView.cshtml"
+#line 263 "NoteRazorView.cshtml"
                                                                                                                         , Tuple.Create<string,object,bool> ("", Model.Language["note_italic"]
 
 #line default
@@ -378,7 +382,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 256 "NoteRazorView.cshtml"
+#line 263 "NoteRazorView.cshtml"
                                                                                                                                                                                                  WriteLiteral(Model.Icon["format-italic"]);
 
 #line default
@@ -401,7 +405,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 258 "NoteRazorView.cshtml"
+#line 265 "NoteRazorView.cshtml"
                                                                                                                                   , Tuple.Create<string,object,bool> ("", Model.Language["note_underline"]
 
 #line default
@@ -411,7 +415,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 258 "NoteRazorView.cshtml"
+#line 265 "NoteRazorView.cshtml"
                                                                                                                                                                                                               WriteLiteral(Model.Icon["format-underline"]);
 
 #line default
@@ -428,7 +432,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 259 "NoteRazorView.cshtml"
+#line 266 "NoteRazorView.cshtml"
                                                                                                                             , Tuple.Create<string,object,bool> ("", Model.Language["note_strike"]
 
 #line default
@@ -438,7 +442,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 259 "NoteRazorView.cshtml"
+#line 266 "NoteRazorView.cshtml"
                                                                                                                                                                                                      WriteLiteral(Model.Icon["format-strikethrough"]);
 
 #line default
@@ -455,7 +459,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 260 "NoteRazorView.cshtml"
+#line 267 "NoteRazorView.cshtml"
                                                                                                                                       , Tuple.Create<string,object,bool> ("", Model.Language["note_list_ordered"]
 
 #line default
@@ -465,7 +469,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 260 "NoteRazorView.cshtml"
+#line 267 "NoteRazorView.cshtml"
                                                                                                                                                                                                                      WriteLiteral(Model.Icon["format-list-numbers"]);
 
 #line default
@@ -482,7 +486,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 261 "NoteRazorView.cshtml"
+#line 268 "NoteRazorView.cshtml"
                                                                                                                                     , Tuple.Create<string,object,bool> ("", Model.Language["note_list_unordered"]
 
 #line default
@@ -492,7 +496,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 261 "NoteRazorView.cshtml"
+#line 268 "NoteRazorView.cshtml"
                                                                                                                                                                                                                      WriteLiteral(Model.Icon["format-list-bulleted"]);
 
 #line default
@@ -509,7 +513,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 263 "NoteRazorView.cshtml"
+#line 270 "NoteRazorView.cshtml"
                                                                               , Tuple.Create<string,object,bool> ("", Model.Language["undo"]
 
 #line default
@@ -540,7 +544,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 264 "NoteRazorView.cshtml"
+#line 271 "NoteRazorView.cshtml"
                                                                               , Tuple.Create<string,object,bool> ("", Model.Language["redo"]
 
 #line default
@@ -571,7 +575,7 @@ WriteLiteral(" v-bind:class=\"{ active: ShoppingModeActive }\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 265 "NoteRazorView.cshtml"
+#line 272 "NoteRazorView.cshtml"
                                                                                                      , Tuple.Create<string,object,bool> ("", Model.Language["note_shopping_mode"]
 
 #line default
@@ -581,7 +585,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 265 "NoteRazorView.cshtml"
+#line 272 "NoteRazorView.cshtml"
                                                                                                                                                                                      WriteLiteral(Model.Icon["keyboard_off_outline"]);
 
 #line default
@@ -596,7 +600,7 @@ WriteLiteral(" onclick=\"toggleSearchDialog(); return false;\"");
 
 WriteAttribute ("title", " title=\"", "\""
 
-#line 266 "NoteRazorView.cshtml"
+#line 273 "NoteRazorView.cshtml"
                                                        , Tuple.Create<string,object,bool> ("", Model.Language["search"]
 
 #line default
@@ -606,7 +610,7 @@ WriteAttribute ("title", " title=\"", "\""
 WriteLiteral(">");
 
 
-#line 266 "NoteRazorView.cshtml"
+#line 273 "NoteRazorView.cshtml"
                                                                                                                            WriteLiteral(Model.Icon["magnify"]);
 
 #line default
@@ -614,7 +618,7 @@ WriteLiteral(">");
 WriteLiteral("</button>\r\n");
 
 
-#line 267 "NoteRazorView.cshtml"
+#line 274 "NoteRazorView.cshtml"
 
 
 
@@ -639,13 +643,13 @@ WriteLiteral(" aria-expanded=\"false\"");
 WriteLiteral(">\r\n");
 
 
-#line 270 "NoteRazorView.cshtml"
+#line 277 "NoteRazorView.cshtml"
                         
 
 #line default
 #line hidden
 
-#line 270 "NoteRazorView.cshtml"
+#line 277 "NoteRazorView.cshtml"
                           WriteLiteral(Model.Icon["dots-vertical"]);
 
 #line default
@@ -667,7 +671,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'heading\', 1);\"");
 WriteLiteral(">");
 
 
-#line 273 "NoteRazorView.cshtml"
+#line 280 "NoteRazorView.cshtml"
                                                                                                                                                                   WriteLiteral(Model.Icon["format-header-1"]);
 
 #line default
@@ -675,7 +679,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 273 "NoteRazorView.cshtml"
+#line 280 "NoteRazorView.cshtml"
                                                                                                                                                                                                            Write(Model.Language["note_header1"]);
 
 
@@ -692,7 +696,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'heading\', 2);\"");
 WriteLiteral(">");
 
 
-#line 274 "NoteRazorView.cshtml"
+#line 281 "NoteRazorView.cshtml"
                                                                                                                                                                   WriteLiteral(Model.Icon["format-header-2"]);
 
 #line default
@@ -700,7 +704,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 274 "NoteRazorView.cshtml"
+#line 281 "NoteRazorView.cshtml"
                                                                                                                                                                                                            Write(Model.Language["note_header2"]);
 
 
@@ -717,7 +721,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'heading\', 3);\"");
 WriteLiteral(">");
 
 
-#line 275 "NoteRazorView.cshtml"
+#line 282 "NoteRazorView.cshtml"
                                                                                                                                                                   WriteLiteral(Model.Icon["format-header-3"]);
 
 #line default
@@ -725,7 +729,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 275 "NoteRazorView.cshtml"
+#line 282 "NoteRazorView.cshtml"
                                                                                                                                                                                                            Write(Model.Language["note_header3"]);
 
 
@@ -742,7 +746,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'underline\');\"");
 WriteLiteral(">");
 
 
-#line 276 "NoteRazorView.cshtml"
+#line 283 "NoteRazorView.cshtml"
                                                                                                                                                                                                WriteLiteral(Model.Icon["format-underline"]);
 
 #line default
@@ -750,7 +754,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 276 "NoteRazorView.cshtml"
+#line 283 "NoteRazorView.cshtml"
                                                                                                                                                                                                                                          Write(Model.Language["note_underline"]);
 
 
@@ -767,7 +771,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'strike\');\"");
 WriteLiteral(">");
 
 
-#line 277 "NoteRazorView.cshtml"
+#line 284 "NoteRazorView.cshtml"
                                                                                                                                                                                          WriteLiteral(Model.Icon["format-strikethrough"]);
 
 #line default
@@ -775,7 +779,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 277 "NoteRazorView.cshtml"
+#line 284 "NoteRazorView.cshtml"
                                                                                                                                                                                                                                        Write(Model.Language["note_strike"]);
 
 
@@ -792,7 +796,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'orderedlist\');\"");
 WriteLiteral(">");
 
 
-#line 278 "NoteRazorView.cshtml"
+#line 285 "NoteRazorView.cshtml"
                                                                                                                                                                                                    WriteLiteral(Model.Icon["format-list-numbers"]);
 
 #line default
@@ -800,7 +804,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 278 "NoteRazorView.cshtml"
+#line 285 "NoteRazorView.cshtml"
                                                                                                                                                                                                                                                 Write(Model.Language["note_list_ordered"]);
 
 
@@ -817,7 +821,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'bulletlist\');\"");
 WriteLiteral(">");
 
 
-#line 279 "NoteRazorView.cshtml"
+#line 286 "NoteRazorView.cshtml"
                                                                                                                                                                                                  WriteLiteral(Model.Icon["format-list-bulleted"]);
 
 #line default
@@ -825,7 +829,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 279 "NoteRazorView.cshtml"
+#line 286 "NoteRazorView.cshtml"
                                                                                                                                                                                                                                                Write(Model.Language["note_list_unordered"]);
 
 
@@ -842,7 +846,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'codeblock\');\"");
 WriteLiteral(">");
 
 
-#line 280 "NoteRazorView.cshtml"
+#line 287 "NoteRazorView.cshtml"
                                                                                                                                                               WriteLiteral(Model.Icon["code-braces"]);
 
 #line default
@@ -850,7 +854,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 280 "NoteRazorView.cshtml"
+#line 287 "NoteRazorView.cshtml"
                                                                                                                                                                                                    Write(Model.Language["note_code"]);
 
 
@@ -867,7 +871,7 @@ WriteLiteral(" onclick=\"toggleFormat(\'blockquote\');\"");
 WriteLiteral(">");
 
 
-#line 281 "NoteRazorView.cshtml"
+#line 288 "NoteRazorView.cshtml"
                                                                                                                                                                 WriteLiteral(Model.Icon["format-quote-close"]);
 
 #line default
@@ -875,7 +879,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 281 "NoteRazorView.cshtml"
+#line 288 "NoteRazorView.cshtml"
                                                                                                                                                                                                             Write(Model.Language["note_quotation"]);
 
 
@@ -892,7 +896,7 @@ WriteLiteral(" onclick=\"showLinkDialog();\"");
 WriteLiteral(">");
 
 
-#line 282 "NoteRazorView.cshtml"
+#line 289 "NoteRazorView.cshtml"
                                                                                                                                  WriteLiteral(Model.Icon["link-variant"]);
 
 #line default
@@ -900,7 +904,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 282 "NoteRazorView.cshtml"
+#line 289 "NoteRazorView.cshtml"
                                                                                                                                                                        Write(Model.Language["note_link"]);
 
 
@@ -923,7 +927,7 @@ WriteLiteral(" data-target=\"#colorPaletteModal\"");
 WriteLiteral(">");
 
 
-#line 284 "NoteRazorView.cshtml"
+#line 291 "NoteRazorView.cshtml"
                                                                                                                                                           WriteLiteral(Model.Icon["palette"]);
 
 #line default
@@ -931,7 +935,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 284 "NoteRazorView.cshtml"
+#line 291 "NoteRazorView.cshtml"
                                                                                                                                                                                            Write(Model.Language["note_colors"]);
 
 
@@ -940,13 +944,13 @@ WriteLiteral(" ");
 WriteLiteral("</div>\r\n");
 
 
-#line 285 "NoteRazorView.cshtml"
+#line 292 "NoteRazorView.cshtml"
                         
 
 #line default
 #line hidden
 
-#line 285 "NoteRazorView.cshtml"
+#line 292 "NoteRazorView.cshtml"
                          if (Model.CanKeepScreenOn)
                         {
 
@@ -964,7 +968,7 @@ WriteLiteral(" v-on:click=\"KeepScreenOnCommand\"");
 WriteLiteral(">");
 
 
-#line 287 "NoteRazorView.cshtml"
+#line 294 "NoteRazorView.cshtml"
                                                                                                                                         WriteLiteral(Model.Icon["alarm-plus"]);
 
 #line default
@@ -972,7 +976,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 287 "NoteRazorView.cshtml"
+#line 294 "NoteRazorView.cshtml"
                                                                                                                                                                             Write(Model.KeepScreenOnTitle);
 
 
@@ -981,7 +985,7 @@ WriteLiteral(" ");
 WriteLiteral("</div>\r\n");
 
 
-#line 288 "NoteRazorView.cshtml"
+#line 295 "NoteRazorView.cshtml"
                         }
 
 
@@ -998,7 +1002,7 @@ WriteLiteral(" v-on:click=\"TogglePinnedCommand\"");
 WriteLiteral(">");
 
 
-#line 289 "NoteRazorView.cshtml"
+#line 296 "NoteRazorView.cshtml"
                                                                                                                                                         WriteLiteral(Model.Icon["pin"]);
 
 #line default
@@ -1006,7 +1010,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 289 "NoteRazorView.cshtml"
+#line 296 "NoteRazorView.cshtml"
                                                                                                                                                                                      Write(Model.Language["note_pin"]);
 
 
@@ -1023,7 +1027,7 @@ WriteLiteral(" v-on:click=\"ShowInfoCommand\"");
 WriteLiteral(">");
 
 
-#line 290 "NoteRazorView.cshtml"
+#line 297 "NoteRazorView.cshtml"
                                                                                                                                   WriteLiteral(Model.Icon["information"]);
 
 #line default
@@ -1031,7 +1035,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 290 "NoteRazorView.cshtml"
+#line 297 "NoteRazorView.cshtml"
                                                                                                                                                                        Write(Model.Language["note_show_info"]);
 
 
@@ -1040,13 +1044,13 @@ WriteLiteral(" ");
 WriteLiteral("</div>\r\n");
 
 
-#line 291 "NoteRazorView.cshtml"
+#line 298 "NoteRazorView.cshtml"
                         
 
 #line default
 #line hidden
 
-#line 291 "NoteRazorView.cshtml"
+#line 298 "NoteRazorView.cshtml"
                          if (Model.ShowManualSynchronization)
                         {
 
@@ -1072,7 +1076,7 @@ WriteLiteral(" v-on:click=\"PushNoteToOnlineStorageCommand\"");
 WriteLiteral(">");
 
 
-#line 294 "NoteRazorView.cshtml"
+#line 301 "NoteRazorView.cshtml"
                                                                                                                                                      WriteLiteral(Model.Icon["cloud-upload"]);
 
 #line default
@@ -1080,7 +1084,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 294 "NoteRazorView.cshtml"
+#line 301 "NoteRazorView.cshtml"
                                                                                                                                                                                            Write(Model.Language["note_push_to_server"]);
 
 
@@ -1099,7 +1103,7 @@ WriteLiteral(" v-on:click=\"PullNoteFromOnlineStorageCommand\"");
 WriteLiteral(">");
 
 
-#line 295 "NoteRazorView.cshtml"
+#line 302 "NoteRazorView.cshtml"
                                                                                                                                                        WriteLiteral(Model.Icon["cloud-download"]);
 
 #line default
@@ -1107,7 +1111,7 @@ WriteLiteral(">");
 WriteLiteral(" ");
 
 
-#line 295 "NoteRazorView.cshtml"
+#line 302 "NoteRazorView.cshtml"
                                                                                                                                                                                                Write(Model.Language["note_pull_from_server"]);
 
 
@@ -1116,7 +1120,7 @@ WriteLiteral(" ");
 WriteLiteral("</div>\r\n");
 
 
-#line 296 "NoteRazorView.cshtml"
+#line 303 "NoteRazorView.cshtml"
                         }
 
 
@@ -1125,7 +1129,7 @@ WriteLiteral("</div>\r\n");
 WriteLiteral("                    </div>\r\n                </div>\r\n");
 
 
-#line 299 "NoteRazorView.cshtml"
+#line 306 "NoteRazorView.cshtml"
             }
 
 
@@ -1142,13 +1146,13 @@ WriteLiteral(" v-bind:style=\"{ backgroundColor: BackgroundColorHex }\"");
 WriteLiteral(">\r\n");
 
 
-#line 303 "NoteRazorView.cshtml"
+#line 310 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 303 "NoteRazorView.cshtml"
+#line 310 "NoteRazorView.cshtml"
              if (Model.IsLocked)
             {
 
@@ -1176,7 +1180,7 @@ WriteLiteral(" xlink:href=\"#svg-lock-outline\"");
 WriteLiteral(" /></svg></span>\r\n");
 
 
-#line 306 "NoteRazorView.cshtml"
+#line 313 "NoteRazorView.cshtml"
             }
             else
             {
@@ -1194,7 +1198,7 @@ WriteAttribute ("class", " class=\"", "\""
 , Tuple.Create<string,object,bool> ("", "note-viewer", true)
 , Tuple.Create<string,object,bool> (" ", "detail-view", true)
 
-#line 309 "NoteRazorView.cshtml"
+#line 316 "NoteRazorView.cshtml"
                                 , Tuple.Create<string,object,bool> (" ", Model.CssClassNoteType
 
 #line default
@@ -1204,7 +1208,7 @@ WriteAttribute ("class", " class=\"", "\""
 WriteLiteral("></div>\r\n");
 
 
-#line 310 "NoteRazorView.cshtml"
+#line 317 "NoteRazorView.cshtml"
             }
 
 
@@ -1234,7 +1238,7 @@ WriteLiteral(" v-bind:disabled=\"ShoppingModeActive\"");
 
 WriteAttribute ("placeholder", " placeholder=\'", "\'"
 
-#line 316 "NoteRazorView.cshtml"
+#line 323 "NoteRazorView.cshtml"
                                                                      , Tuple.Create<string,object,bool> ("", Model.Language["tag_add"]
 
 #line default
@@ -1418,13 +1422,13 @@ WriteLiteral(" class=\"d-flex flex-wrap\"");
 WriteLiteral(">\r\n");
 
 
-#line 346 "NoteRazorView.cshtml"
+#line 353 "NoteRazorView.cshtml"
                         
 
 #line default
 #line hidden
 
-#line 346 "NoteRazorView.cshtml"
+#line 353 "NoteRazorView.cshtml"
                          foreach (var backgroundColor in @Model.BackgroundColorsHex)
                         {
 
@@ -1439,7 +1443,7 @@ WriteAttribute ("class", " class=\"", "\""
 , Tuple.Create<string,object,bool> (" ", "justify-content-center", true)
 , Tuple.Create<string,object,bool> (" ", "color-btn", true)
 
-#line 348 "NoteRazorView.cshtml"
+#line 355 "NoteRazorView.cshtml"
                                                            , Tuple.Create<string,object,bool> (" ", Model.GetDarkClass(backgroundColor)
 
 #line default
@@ -1451,7 +1455,7 @@ WriteLiteral(" data-dismiss=\"modal\"");
 WriteAttribute ("v-on:click", " v-on:click=\"", "\""
 , Tuple.Create<string,object,bool> ("", "BackgroundColorHex=\'", true)
 
-#line 348 "NoteRazorView.cshtml"
+#line 355 "NoteRazorView.cshtml"
                                                                                                                                                         , Tuple.Create<string,object,bool> ("", backgroundColor
 
 #line default
@@ -1462,7 +1466,7 @@ WriteAttribute ("v-on:click", " v-on:click=\"", "\""
 WriteAttribute ("style", " style=\"", "\""
 , Tuple.Create<string,object,bool> ("", "background-color:", true)
 
-#line 348 "NoteRazorView.cshtml"
+#line 355 "NoteRazorView.cshtml"
                                                                                                                                                                                                     , Tuple.Create<string,object,bool> (" ", backgroundColor
 
 #line default
@@ -1472,7 +1476,7 @@ WriteAttribute ("style", " style=\"", "\""
 WriteLiteral("><span>Lorem ipsum</span></div>\r\n");
 
 
-#line 349 "NoteRazorView.cshtml"
+#line 356 "NoteRazorView.cshtml"
                         }
 
 
@@ -1553,7 +1557,7 @@ WriteLiteral(" onclick=\"linkDialogOkPressed();\"");
 WriteLiteral(">");
 
 
-#line 365 "NoteRazorView.cshtml"
+#line 372 "NoteRazorView.cshtml"
                                                                                                 Write(Model.Language["ok"]);
 
 
@@ -1570,7 +1574,7 @@ WriteLiteral(" onclick=\"linkDialogOpenPressed();\"");
 WriteLiteral(">");
 
 
-#line 366 "NoteRazorView.cshtml"
+#line 373 "NoteRazorView.cshtml"
                                                                                                     Write(Model.Language["note_open_link"]);
 
 
@@ -1599,7 +1603,7 @@ WriteLiteral(" data-dismiss=\"modal\"");
 WriteLiteral(">");
 
 
-#line 367 "NoteRazorView.cshtml"
+#line 374 "NoteRazorView.cshtml"
                                                                                       Write(Model.Language["cancel"]);
 
 
@@ -1609,13 +1613,13 @@ WriteLiteral("</button>\r\n                    </div>\r\n                </div>\
 "\r\n        </div>\r\n\r\n        <div hidden>\r\n");
 
 
-#line 374 "NoteRazorView.cshtml"
+#line 381 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 374 "NoteRazorView.cshtml"
+#line 381 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("lock-outline", new[] { new KeyValuePair<string, string>("id", "svg-lock-outline") }));
 
 #line default
@@ -1623,13 +1627,13 @@ WriteLiteral("</button>\r\n                    </div>\r\n                </div>\
 WriteLiteral("\r\n");
 
 
-#line 375 "NoteRazorView.cshtml"
+#line 382 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 375 "NoteRazorView.cshtml"
+#line 382 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("close-circle-outline", new[] { new KeyValuePair<string, string>("id", "svg-close-circle-outline") }));
 
 #line default
@@ -1637,13 +1641,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 376 "NoteRazorView.cshtml"
+#line 383 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 376 "NoteRazorView.cshtml"
+#line 383 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("plus", new[] { new KeyValuePair<string, string>("id", "svg-plus") }));
 
 #line default
@@ -1651,13 +1655,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 377 "NoteRazorView.cshtml"
+#line 384 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 377 "NoteRazorView.cshtml"
+#line 384 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("delete", new[] { new KeyValuePair<string, string>("id", "svg-delete") }));
 
 #line default
@@ -1665,13 +1669,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 378 "NoteRazorView.cshtml"
+#line 385 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 378 "NoteRazorView.cshtml"
+#line 385 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("link-variant", new[] { new KeyValuePair<string, string>("id", "svg-link-variant") }));
 
 #line default
@@ -1679,13 +1683,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 379 "NoteRazorView.cshtml"
+#line 386 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 379 "NoteRazorView.cshtml"
+#line 386 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("open-in-new", new[] { new KeyValuePair<string, string>("id", "svg-open-in-new") }));
 
 #line default
@@ -1693,13 +1697,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 380 "NoteRazorView.cshtml"
+#line 387 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 380 "NoteRazorView.cshtml"
+#line 387 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("chevron-up", new[] { new KeyValuePair<string, string>("id", "svg-chevron-up") }));
 
 #line default
@@ -1707,13 +1711,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 381 "NoteRazorView.cshtml"
+#line 388 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 381 "NoteRazorView.cshtml"
+#line 388 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("chevron-down", new[] { new KeyValuePair<string, string>("id", "svg-chevron-down") }));
 
 #line default
@@ -1721,13 +1725,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 382 "NoteRazorView.cshtml"
+#line 389 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 382 "NoteRazorView.cshtml"
+#line 389 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("undo", new[] { new KeyValuePair<string, string>("id", "svg-undo") }));
 
 #line default
@@ -1735,13 +1739,13 @@ WriteLiteral("\r\n");
 WriteLiteral("\r\n");
 
 
-#line 383 "NoteRazorView.cshtml"
+#line 390 "NoteRazorView.cshtml"
             
 
 #line default
 #line hidden
 
-#line 383 "NoteRazorView.cshtml"
+#line 390 "NoteRazorView.cshtml"
               WriteLiteral(Model.Icon.LoadIcon("redo", new[] { new KeyValuePair<string, string>("id", "svg-redo") }));
 
 #line default

--- a/src/SilentNotes.Shared/Views/NoteRazorView.cshtml
+++ b/src/SilentNotes.Shared/Views/NoteRazorView.cshtml
@@ -39,10 +39,17 @@ body { background-color: transparent; }
     <script>
         var editor;
         var linkDialog;
+        var ignoreViewModelUpdate = true;
+
+        /* Starts notifying the viewmodel about changes. Call it as soon as the content is completely loaded. */
+        function startSendingViewModelUpdates() {
+            ignoreViewModelUpdate = false;
+        }
 
         /* Notifies the viewmodel about changes in the note content. */
         function triggerViewModelUpdate() {
-            vuePropertyChanged('UnlockedHtmlContent', null);
+            if (!ignoreViewModelUpdate)
+                vuePropertyChanged('UnlockedHtmlContent', null);
         }
 
         function getSearchDialogElement() {

--- a/src/Tests/KdfCostFactorTest/Resources/Resource.designer.cs
+++ b/src/Tests/KdfCostFactorTest/Resources/Resource.designer.cs
@@ -14,7 +14,7 @@ namespace KdfCostFactorTest
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.2.0.155")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.0.0.73")]
 	public partial class Resource
 	{
 		


### PR DESCRIPTION
There was a tiny time slot where the editor already triggered modification events, while loading of the note content was not yet completed.