### PR TITLE
Fix/reload page

### DIFF
--- a/src/SilentNotes.AllPlatforms/RouteNames.cs
+++ b/src/SilentNotes.AllPlatforms/RouteNames.cs
@@ -14,8 +14,7 @@ namespace SilentNotes
     /// </summary>
     public static class RouteNames
     {
-        public const string Home = NoteRepository;
-        public const string NoteRepository = "/";
+        public const string NoteRepository = "/noterepository";
         public const string Note = "/note";
         public const string Checklist = "/checklist";
         public const string ChangePassword = "/changepassword";
@@ -31,6 +30,8 @@ namespace SilentNotes
         public const string Settings = "/settings";
         public const string TransferCodePrompt = "/transfercodeprompt";
         public const string TransferCodeHistory = "/transfercodehistory";
+
+        public const string ForceLoad = "/forceload";
 
         /// <summary>
         /// Combines a route name with parameters.

--- a/src/SilentNotes.AllPlatforms/Services/NavigationService.cs
+++ b/src/SilentNotes.AllPlatforms/Services/NavigationService.cs
@@ -33,7 +33,7 @@ namespace SilentNotes.Services
         /// </summary>
         /// <param name="navigationManager">The navigation manager to wrap.</param>
         /// <param name="startRoute">The route of the first shown page.</param>
-        public NavigationService(NavigationManager navigationManager, string startRoute = RouteNames.Home)
+        public NavigationService(NavigationManager navigationManager, string startRoute)
         {
             System.Diagnostics.Debug.WriteLine("*** Scoped NavigationService create " + Id);
             _navigationManager = navigationManager;
@@ -59,7 +59,7 @@ namespace SilentNotes.Services
         {
             if (reload)
             {
-                uri = RouteNames.Combine("/forceload", uri);
+                uri = RouteNames.Combine(RouteNames.ForceLoad, uri);
             }
 
             _navigationManager.NavigateTo(uri, ForceLoadNever, ReplaceWebviewHistoryAlways);
@@ -71,14 +71,14 @@ namespace SilentNotes.Services
             // Only a "forceReload" would reliably reload the new content of the page.
             // Since we don't want to use "forceReload" (see const ForceLoadNever), we call
             // a route which immediately redirects to our target route.
-            string forceLoadRoute = RouteNames.Combine("/forceload", _currentLocation);
+            string forceLoadRoute = RouteNames.Combine(RouteNames.ForceLoad, _currentLocation);
             _navigationManager.NavigateTo(forceLoadRoute, ForceLoadNever, ReplaceWebviewHistoryAlways);
         }
 
         /// <inheritdoc/>
         private ValueTask LocationChangingHandler(LocationChangingContext context)
         {
-            if (context.TargetLocation.StartsWith("/forceload/"))
+            if (context.TargetLocation.StartsWith(RouteNames.ForceLoad))
                 return ValueTask.CompletedTask;
 
             string currentRoute = ExtractRouteName(_currentLocation, _navigationManager.BaseUri);

--- a/src/SilentNotes.AllPlatforms/Services/NavigationService.cs
+++ b/src/SilentNotes.AllPlatforms/Services/NavigationService.cs
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 using System;
+using System.Text;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.AspNetCore.Components;
@@ -59,7 +60,10 @@ namespace SilentNotes.Services
         {
             if (reload)
             {
-                uri = RouteNames.Combine(RouteNames.ForceLoad, uri);
+                // Only a "forceReload" would reliably reload the new content of the page.
+                // Since we don't want to use "forceReload" (see const ForceLoadNever), we call
+                // a route which immediately redirects to our target route.
+                uri = RouteNames.Combine(RouteNames.ForceLoad, HexEncode(uri));
             }
 
             _navigationManager.NavigateTo(uri, ForceLoadNever, ReplaceWebviewHistoryAlways);
@@ -68,11 +72,13 @@ namespace SilentNotes.Services
         /// <inheritdoc/>
         public void NavigateReload()
         {
-            // Only a "forceReload" would reliably reload the new content of the page.
-            // Since we don't want to use "forceReload" (see const ForceLoadNever), we call
-            // a route which immediately redirects to our target route.
-            string forceLoadRoute = RouteNames.Combine(RouteNames.ForceLoad, _currentLocation);
-            _navigationManager.NavigateTo(forceLoadRoute, ForceLoadNever, ReplaceWebviewHistoryAlways);
+            NavigateTo(_currentLocation, true);
+        }
+
+        private static string HexEncode(string text)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(text);
+            return Convert.ToHexString(bytes);
         }
 
         /// <inheritdoc/>

--- a/src/SilentNotes.AllPlatforms/Stories/SynchronizationStory/StopAndShowRepositoryStep.cs
+++ b/src/SilentNotes.AllPlatforms/Stories/SynchronizationStory/StopAndShowRepositoryStep.cs
@@ -32,7 +32,7 @@ namespace SilentNotes.Stories.SynchronizationStory
                 synchronizationService.FinishedManualSynchronization(serviceProvider);
 
                 var navigation = serviceProvider.GetService<INavigationService>();
-                navigation.NavigateTo(RouteNames.Home, true);
+                navigation.NavigateTo(RouteNames.NoteRepository, true);
             }
             return ToTask(ToResultEndOfStory());
         }

--- a/src/SilentNotes.AllPlatforms/ViewModels/ChangePasswordViewModel.cs
+++ b/src/SilentNotes.AllPlatforms/ViewModels/ChangePasswordViewModel.cs
@@ -87,7 +87,7 @@ namespace SilentNotes.ViewModels
                 safeInfo.Safe.RefreshModifiedAt();
             }
 
-            _navigationService.NavigateTo(RouteNames.Home);
+            _navigationService.NavigateTo(RouteNames.NoteRepository);
         }
 
         public bool HasOldPasswordError

--- a/src/SilentNotes.AllPlatforms/ViewModels/ExportViewModel.cs
+++ b/src/SilentNotes.AllPlatforms/ViewModels/ExportViewModel.cs
@@ -74,7 +74,7 @@ namespace SilentNotes.ViewModels
                 if (success)
                 {
                     _feedbackService.ShowToast(Language.LoadText("export_success"));
-                    _navigationService.NavigateTo(RouteNames.Home);
+                    _navigationService.NavigateTo(RouteNames.NoteRepository);
                 }
                 else
                 {

--- a/src/SilentNotes.AllPlatforms/ViewModels/OpenSafeViewModel.cs
+++ b/src/SilentNotes.AllPlatforms/ViewModels/OpenSafeViewModel.cs
@@ -109,7 +109,7 @@ namespace SilentNotes.ViewModels
             }
             else if (string.IsNullOrEmpty(_navigationTargetRoute))
             {
-                _navigationService.NavigateTo(RouteNames.Home);
+                _navigationService.NavigateTo(RouteNames.NoteRepository);
             }
             else
             {

--- a/src/SilentNotes.AllPlatforms/Views/PageBase.cs
+++ b/src/SilentNotes.AllPlatforms/Views/PageBase.cs
@@ -50,7 +50,7 @@ namespace SilentNotes.Views
         /// the back key on Android, a value of null will then close the application.
         /// Default value is the home route.
         /// </summary>
-        public string BackRoute { get; set; } = RouteNames.Home;
+        public string BackRoute { get; set; } = RouteNames.NoteRepository;
 
         /// <inheritdoc/>
         public async ValueTask DisposeAsync()

--- a/src/SilentNotes.Blazor/Views/ChangePassword.razor
+++ b/src/SilentNotes.Blazor/Views/ChangePassword.razor
@@ -1,4 +1,4 @@
-﻿@page "/changepassword"
+﻿@attribute [Route(RouteNames.ChangePassword)]
 @inherits PageBase
 
 @using System.ComponentModel;

--- a/src/SilentNotes.Blazor/Views/ChecklistPage.razor
+++ b/src/SilentNotes.Blazor/Views/ChecklistPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/checklist/{NoteId}"
+﻿@attribute [Route(RouteNames.Checklist + "/{NoteId}")]
 @inherits PageBase
 
 @using System.ComponentModel
@@ -313,7 +313,7 @@ div.dark .detail-view.checklist .ProseMirror p::after { content: @(IconService.L
 
 		if (ViewModel.Model == NoteModel.NotFound)
 			// Redirect to home if note was not found
-			NavigationService.NavigateTo(RouteNames.Home);
+			NavigationService.NavigateTo(RouteNames.NoteRepository);
 		else if (ViewModel.IsLocked)
 			// Redirect to open safe if locked
 			NavigationService.NavigateTo(ViewModel.Route);

--- a/src/SilentNotes.Blazor/Views/ExportPage.razor
+++ b/src/SilentNotes.Blazor/Views/ExportPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/export"
+﻿@attribute [Route(RouteNames.Export)]
 @inherits PageBase
 
 @using SilentNotes.Models

--- a/src/SilentNotes.Blazor/Views/ForceLoadPage.razor
+++ b/src/SilentNotes.Blazor/Views/ForceLoadPage.razor
@@ -1,7 +1,9 @@
-﻿@page "/forceload/{TargetUri}"
+﻿@attribute [Route(RouteNames.ForceLoad + "/{TargetUri}")]
 
 @* This route is used to reload the content of an already open page, it immediately redirects to
 another route. For more information see the implementation of INavigationService *@
+
+<div>Reloading page</div>
 
 @code {
 	[Inject] private NavigationManager _navigationManager { get; set; }

--- a/src/SilentNotes.Blazor/Views/ForceLoadPage.razor
+++ b/src/SilentNotes.Blazor/Views/ForceLoadPage.razor
@@ -1,4 +1,6 @@
-﻿@attribute [Route(RouteNames.ForceLoad + "/{TargetUri}")]
+﻿@attribute [Route(RouteNames.ForceLoad + "/{TargetUriHexEncoded}")]
+
+@inject NavigationManager NavigationManager
 
 @* This route is used to reload the content of an already open page, it immediately redirects to
 another route. For more information see the implementation of INavigationService *@
@@ -6,13 +8,22 @@ another route. For more information see the implementation of INavigationService
 <div>Reloading page</div>
 
 @code {
-	[Inject] private NavigationManager _navigationManager { get; set; }
-
+	/// <summary>
+	/// The hex encoding of the target url avoids any wrong interpretation, even with future
+	/// implementations of the NavigationManager.
+	/// </summary>
 	[Parameter]
-	public string TargetUri { get; set; }
+	public string TargetUriHexEncoded { get; set; }
 
 	protected override void OnParametersSet()
 	{
-		_navigationManager.NavigateTo(TargetUri, false, true);
+		string decodedTargetUri = HexDecode(TargetUriHexEncoded);
+		NavigationManager.NavigateTo(decodedTargetUri, false, true);
+	}
+
+	private static string HexDecode(string hexEncodedText)
+	{
+		byte[] bytes = Convert.FromHexString(hexEncodedText);
+		return System.Text.Encoding.UTF8.GetString(bytes, 0, bytes.Length);
 	}
 }

--- a/src/SilentNotes.Blazor/Views/InfoPage.razor
+++ b/src/SilentNotes.Blazor/Views/InfoPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/info"
+﻿@attribute [Route(RouteNames.Info)]
 @inherits PageBase
 
 @using SilentNotes.Models

--- a/src/SilentNotes.Blazor/Views/NotePage.razor
+++ b/src/SilentNotes.Blazor/Views/NotePage.razor
@@ -1,4 +1,4 @@
-﻿@page "/note/{NoteId}"
+﻿@attribute [Route(RouteNames.Note + "/{NoteId}")]
 @inherits PageBase
 
 @using System.ComponentModel
@@ -349,7 +349,7 @@
 
 		if (ViewModel.Model == NoteModel.NotFound)
 			// Redirect to home if note was not found
-			NavigationService.NavigateTo(RouteNames.Home);
+			NavigationService.NavigateTo(RouteNames.NoteRepository);
 		else if (ViewModel.IsLocked)
 			// Redirect to open safe if locked
 			NavigationService.NavigateTo(ViewModel.Route);

--- a/src/SilentNotes.Blazor/Views/NoteRepositoryPage.razor
+++ b/src/SilentNotes.Blazor/Views/NoteRepositoryPage.razor
@@ -1,5 +1,6 @@
-﻿@page "/"
-@page "/bringtoview/{BringToViewNoteId}"
+﻿@attribute [Route("/")]
+@attribute [Route(RouteNames.NoteRepository)]
+@attribute [Route(RouteNames.NoteRepository + "bringtoview/{BringToViewNoteId}")]
 @inherits PageBase
 
 @using System.ComponentModel

--- a/src/SilentNotes.Blazor/Views/OpenSafePage.razor
+++ b/src/SilentNotes.Blazor/Views/OpenSafePage.razor
@@ -1,5 +1,5 @@
-﻿@page "/opensafe"
-@page "/opensafe/target/{TargetRoute}"
+﻿@attribute [Route(RouteNames.OpenSafe)]
+@attribute [Route(RouteNames.OpenSafe + "/{TargetRoute}")]
 @inherits PageBase
 
 @using System.ComponentModel;
@@ -23,7 +23,7 @@
 
 @* Main menu *@
 <MudAppBar Class="flex-none" Fixed="true" Dense="true" WrapContent="false">
-	<MudIconButton OnClick="@(() => Navigation.NavigateTo(RouteNames.Home))" Icon="@IconService[IconNames.ArrowLeft]" Color="Color.Inherit" Class="mr-5" Title="@LanguageService["back"]" Edge="Edge.Start" />
+	<MudIconButton OnClick="@(() => Navigation.NavigateTo(RouteNames.NoteRepository))" Icon="@IconService[IconNames.ArrowLeft]" Color="Color.Inherit" Class="mr-5" Title="@LanguageService["back"]" Edge="Edge.Start" />
 
 	<MudSpacer/>
 
@@ -80,7 +80,7 @@
 			</MudForm>
 
 			<MudStack Class="my-4" Row="true" Justify="Justify.FlexEnd" Spacing="1">
-				<MudButton OnClick="@(() => Navigation.NavigateTo(RouteNames.Home))" Color="Color.Default" Variant="Variant.Filled">@LanguageService["cancel"]</MudButton>
+				<MudButton OnClick="@(() => Navigation.NavigateTo(RouteNames.NoteRepository))" Color="Color.Default" Variant="Variant.Filled">@LanguageService["cancel"]</MudButton>
 				<MudButton @ref="_okButton" OnClick="@(() => ViewModel.OkCommand.Execute(null))" Color="Color.Primary" Variant="Variant.Filled">@LanguageService["ok"]</MudButton>
 			</MudStack>
 
@@ -111,7 +111,7 @@
 			await KeyboardShortcuts.InitializeAsync(JSRuntime);
 			KeyboardShortcuts
 				.SetCloseMenuShortcut(new SnKeyboardShortcut(SnKey.Escape), OnCloseMenuOrDialog)
-				.AddShortcut(new SnKeyboardShortcut(SnKey.Escape), () => Navigation.NavigateTo(RouteNames.Home))
+				.AddShortcut(new SnKeyboardShortcut(SnKey.Escape), () => Navigation.NavigateTo(RouteNames.NoteRepository))
 				.AddShortcut(new SnKeyboardShortcut(SnKey.Enter), async () => await SnKeyboardShortcuts.SimulateClickAsync(_okButton));
 		}
 	}

--- a/src/SilentNotes.Blazor/Views/RecycleBinPage.razor
+++ b/src/SilentNotes.Blazor/Views/RecycleBinPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/recyclebin"
+﻿@attribute [Route(RouteNames.RecycleBin)]
 @inherits PageBase
 
 @using System.ComponentModel;

--- a/src/SilentNotes.Blazor/Views/SettingsPage.razor
+++ b/src/SilentNotes.Blazor/Views/SettingsPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/settings"
+﻿@attribute [Route(RouteNames.Settings)]
 @inherits PageBase
 
 @using System.ComponentModel

--- a/src/SilentNotes.Blazor/Views/SynchronizationStory/CloudStorageAccountPage.razor
+++ b/src/SilentNotes.Blazor/Views/SynchronizationStory/CloudStorageAccountPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/cloudstorageaccount"
+﻿@attribute [Route(RouteNames.CloudStorageAccount)]
 @inherits PageBase
 
 @using System.Security

--- a/src/SilentNotes.Blazor/Views/SynchronizationStory/CloudStorageChoicePage.razor
+++ b/src/SilentNotes.Blazor/Views/SynchronizationStory/CloudStorageChoicePage.razor
@@ -1,4 +1,4 @@
-﻿@page "/cloudstoragechoice"
+﻿@attribute [Route(RouteNames.CloudStorageChoice)]
 @inherits PageBase
 
 @using SilentNotes.Models
@@ -38,7 +38,7 @@
 @code {
 	protected override void OnInitialized()
 	{
-		BackRoute = RouteNames.Home;
+		BackRoute = RouteNames.NoteRepository;
 		ViewModel = new CloudStorageChoiceViewModel(Ioc.Instance);
 	}
 

--- a/src/SilentNotes.Blazor/Views/SynchronizationStory/CloudStorageOauthWaitingPage.razor
+++ b/src/SilentNotes.Blazor/Views/SynchronizationStory/CloudStorageOauthWaitingPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/cloudstorageoauthwaiting"
+﻿@attribute [Route(RouteNames.CloudStorageOauthWaiting)]
 @inherits PageBase
 
 @using SilentNotes.Models

--- a/src/SilentNotes.Blazor/Views/SynchronizationStory/FirstTimeSyncPage.razor
+++ b/src/SilentNotes.Blazor/Views/SynchronizationStory/FirstTimeSyncPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/firsttimesync"
+﻿@attribute [Route(RouteNames.FirstTimeSync)]
 @inherits PageBase
 
 @using SilentNotes.Models
@@ -34,7 +34,7 @@
 
 	protected override void OnInitialized()
 	{
-		BackRoute = RouteNames.Home;
+		BackRoute = RouteNames.NoteRepository;
 		ViewModel = new FirstTimeSyncViewModel(Ioc.Instance);
 	}
 

--- a/src/SilentNotes.Blazor/Views/SynchronizationStory/MergeChoicePage.razor
+++ b/src/SilentNotes.Blazor/Views/SynchronizationStory/MergeChoicePage.razor
@@ -1,4 +1,4 @@
-﻿@page "/mergechoice"
+﻿@attribute [Route(RouteNames.MergeChoice)]
 @inherits PageBase
 
 @using SilentNotes.Models
@@ -59,7 +59,7 @@
 @code {
 	protected override void OnInitialized()
 	{
-		BackRoute = RouteNames.Home;
+		BackRoute = RouteNames.NoteRepository;
 		ViewModel = new MergeChoiceViewModel(Ioc.Instance);
 	}
 

--- a/src/SilentNotes.Blazor/Views/SynchronizationStory/TransferCodePromptPage.razor
+++ b/src/SilentNotes.Blazor/Views/SynchronizationStory/TransferCodePromptPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/transfercodeprompt"
+﻿@attribute [Route(RouteNames.TransferCodePrompt)]
 @inherits PageBase
 
 @using SilentNotes.Models
@@ -43,7 +43,7 @@
 
 	protected override void OnInitialized()
 	{
-		BackRoute = RouteNames.Home;
+		BackRoute = RouteNames.NoteRepository;
 		ViewModel = new TransferCodePromptViewModel(Ioc.Instance);
 	}
 

--- a/src/SilentNotes.Blazor/Views/TransferCodeHistory.razor
+++ b/src/SilentNotes.Blazor/Views/TransferCodeHistory.razor
@@ -1,4 +1,4 @@
-﻿@page "/transfercodehistory"
+﻿@attribute [Route(RouteNames.TransferCodeHistory)]
 @inherits PageBase
 
 @using SilentNotes.Models

--- a/src/SilentNotes.Blazor/obj/SilentNotes.csproj.nuget.dgspec.json
+++ b/src/SilentNotes.Blazor/obj/SilentNotes.csproj.nuget.dgspec.json
@@ -5,7 +5,7 @@
   },
   "projects": {
     "D:\\Source\\SilentNotes\\GitHub\\src\\SilentNotes.Blazor\\SilentNotes.csproj": {
-      "version": "7.99.22",
+      "version": "7.99.23",
       "restore": {
         "projectUniqueName": "D:\\Source\\SilentNotes\\GitHub\\src\\SilentNotes.Blazor\\SilentNotes.csproj",
         "projectName": "SilentNotes",

--- a/src/SilentNotes.Blazor/obj/project.assets.json
+++ b/src/SilentNotes.Blazor/obj/project.assets.json
@@ -27756,7 +27756,7 @@
     "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
   },
   "project": {
-    "version": "7.99.22",
+    "version": "7.99.23",
     "restore": {
       "projectUniqueName": "D:\\Source\\SilentNotes\\GitHub\\src\\SilentNotes.Blazor\\SilentNotes.csproj",
       "projectName": "SilentNotes",


### PR DESCRIPTION
With the newer DotNet version, the interpretation of encoded url parameters in NavigationManager changed. The "ForceReload" route now uses a hex encoding to avoid any (future) problems.