### PR TITLE
Use alternative way to check whether a file exists on OneDrive.

### DIFF
--- a/src/VanillaCloudStorageClient/OAuth2CloudStorageClient.cs
+++ b/src/VanillaCloudStorageClient/OAuth2CloudStorageClient.cs
@@ -112,10 +112,13 @@ namespace VanillaCloudStorageClient
                     .ReceiveString();
 
                 JsonTokenExchangeResponse response = JsonSerializer.Deserialize<JsonTokenExchangeResponse>(jsonResponse);
+                string refreshToken = !string.IsNullOrEmpty(response.RefreshToken)
+                    ? response.RefreshToken // use the new refresh token
+                    : token.RefreshToken; // keep the existing refresh token
                 CloudStorageToken result = new CloudStorageToken
                 {
                     AccessToken = response.AccessToken,
-                    RefreshToken = token.RefreshToken // keep the refresh token
+                    RefreshToken = refreshToken
                 };
                 result.SetExpiryDateBySecondsFromNow(response.ExpiresIn);
                 return result;


### PR DESCRIPTION
Use alternative way to check whether a file exists on OneDrive to overcome the access denied error.
Store refresh token when service returns a new one.
