### PR TITLE
Maintain/rid build

### DIFF
--- a/.github/workflows/build-silentnotes.yml
+++ b/.github/workflows/build-silentnotes.yml
@@ -253,7 +253,7 @@ jobs:
       run: dotnet publish -c Release -p:PublishProfile=${{ env.Profile }} -f ${{ env.Target_Framework_Windows }} -r ${{ env.RuntimeIdentifier }} -p:Platform=${{ env.Platform }} -p:AppxPackageSigningEnabled=true -p:PackageCertificateThumbprint="${{ secrets.SILENTNOTESPFXTHUMBPRINT }}"
       env:
         Platform: ${{ matrix.platform }}
-        RuntimeIdentifier: win-${{ matrix.platform }}
+        RuntimeIdentifier: win10-${{ matrix.platform }}
         Profile: MSIX-win10-${{ matrix.platform }}
         
     # Remove the pfx

--- a/.github/workflows/build-silentnotes.yml
+++ b/.github/workflows/build-silentnotes.yml
@@ -253,7 +253,7 @@ jobs:
       run: dotnet publish -c Release -p:PublishProfile=${{ env.Profile }} -f ${{ env.Target_Framework_Windows }} -r ${{ env.RuntimeIdentifier }} -p:Platform=${{ env.Platform }} -p:AppxPackageSigningEnabled=true -p:PackageCertificateThumbprint="${{ secrets.SILENTNOTESPFXTHUMBPRINT }}"
       env:
         Platform: ${{ matrix.platform }}
-        RuntimeIdentifier: win10-${{ matrix.platform }}
+        RuntimeIdentifier: win-${{ matrix.platform }}
         Profile: MSIX-win10-${{ matrix.platform }}
         
     # Remove the pfx

--- a/src/SilentNotes.Blazor/Properties/PublishProfiles/MSIX-win10-x64.pubxml
+++ b/src/SilentNotes.Blazor/Properties/PublishProfiles/MSIX-win10-x64.pubxml
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <PublishDir>..\..\bin\publish\net8.0-windows-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <UseRidGraph>true</UseRidGraph>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <Platform>x64</Platform>
     <Configuration>Release</Configuration>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>

--- a/src/SilentNotes.Blazor/Properties/PublishProfiles/MSIX-win10-x64.pubxml
+++ b/src/SilentNotes.Blazor/Properties/PublishProfiles/MSIX-win10-x64.pubxml
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PublishDir>..\..\bin\publish\net8.0-windows-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <Platform>x64</Platform>
     <Configuration>Release</Configuration>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>

--- a/src/SilentNotes.Blazor/Properties/PublishProfiles/MSIX-win10-x86.pubxml
+++ b/src/SilentNotes.Blazor/Properties/PublishProfiles/MSIX-win10-x86.pubxml
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <PublishDir>..\..\bin\publish\net8.0-windows-x86\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <UseRidGraph>true</UseRidGraph>
+    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
     <Platform>x86</Platform>
     <Configuration>Release</Configuration>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>

--- a/src/SilentNotes.Blazor/Properties/PublishProfiles/MSIX-win10-x86.pubxml
+++ b/src/SilentNotes.Blazor/Properties/PublishProfiles/MSIX-win10-x86.pubxml
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PublishDir>..\..\bin\publish\net8.0-windows-x86\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <Platform>x86</Platform>
     <Configuration>Release</Configuration>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>


### PR DESCRIPTION
Added backwards compatibility for RuntimeIdentifiers, since we want to switch to .net9 anyway, see https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/rid-graph .
