### PR TITLE
Enforced edge-to-edge feature for Android15+

### DIFF
--- a/src/SilentNotes.Blazor/Platforms/Android/ApplicationEventHandler.cs
+++ b/src/SilentNotes.Blazor/Platforms/Android/ApplicationEventHandler.cs
@@ -30,13 +30,17 @@ namespace SilentNotes.Platforms
         {
             System.Diagnostics.Debug.WriteLine("*** ApplicationEventHandler.OnCreate() " + GetId(activity));
 
-            // Workaround: Android soft keyboard hides the lower part of the content,
-            // see https://learn.microsoft.com/en-us/dotnet/maui/android/platform-specifics/soft-keyboard-input-mode
-            // Seems that from Android 15 onwards this won't be required anymore, because it is handled
-            // correctly by the 'SafeAreaEdges' attrbitute.
-            Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.Application.UseWindowSoftInputModeAdjust(
-                Microsoft.Maui.Controls.Application.Current.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>(),
-                Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust.Resize);
+            bool isAndroid15Plus = System.OperatingSystem.IsAndroidVersionAtLeast(35);
+            if (!isAndroid15Plus)
+            {
+                // Workaround: Android soft keyboard hides the lower part of the content,
+                // see https://learn.microsoft.com/en-us/dotnet/maui/android/platform-specifics/soft-keyboard-input-mode
+                // Seems that from Android 15 onwards this won't be required anymore, because it is handled
+                // correctly by the 'SafeAreaEdges' attrbitute.
+                Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.Application.UseWindowSoftInputModeAdjust(
+                    Microsoft.Maui.Controls.Application.Current.On<Microsoft.Maui.Controls.PlatformConfiguration.Android>(),
+                    Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific.WindowSoftInputModeAdjust.Resize);
+            }
 
             // Inform services about the new main activity.
             Ioc.Instance.GetService<IAppContextService>().Initialize(activity);

--- a/src/SilentNotes.Blazor/Platforms/Android/MainActivity.cs
+++ b/src/SilentNotes.Blazor/Platforms/Android/MainActivity.cs
@@ -29,6 +29,7 @@ namespace SilentNotes
         protected override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
+            AndroidX.Activity.EdgeToEdge.Enable(this);
 
             // Delay closing of splash screen until app is ready:
             // https://developer.android.com/develop/ui/views/launch/splash-screen#suspend-drawing


### PR DESCRIPTION
# Description

.Net 9/10 offer support for the edge-to-edge enforment of Android 15+. Additionally to setting the SafeAreaEdges="All" it seems necessary to enable the support manually.
