### PR TITLE
Added feature to show English UI, regardless of the OS language.

### DIFF
--- a/src/SilentNotes.AllPlatforms/Models/SettingsModel.cs
+++ b/src/SilentNotes.AllPlatforms/Models/SettingsModel.cs
@@ -54,6 +54,7 @@ namespace SilentNotes.Models
             KeepScreenUpDuration = 15;
             UseWallpaper = true;
             RememberLastTagFilter = false;
+            AlwaysEnglish = false;
         }
 
         /// <summary>
@@ -292,6 +293,13 @@ namespace SilentNotes.Models
         /// </summary>
         [XmlElement("prevent_screenshots")]
         public bool PreventScreenshots { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the OS language should be ignored and the
+        /// english preferred if the GUI.
+        /// </summary>
+        [XmlElement("always_english")]
+        public bool AlwaysEnglish {  get; set; }
 
         /// <summary>
         /// Gets a value indicating whether a cloud storage is set.

--- a/src/SilentNotes.AllPlatforms/Services/ILanguageTestService.cs
+++ b/src/SilentNotes.AllPlatforms/Services/ILanguageTestService.cs
@@ -24,5 +24,12 @@ namespace SilentNotes.Services
         /// </summary>
         /// <param name="customResourceFile">The content of a user written language resource file.</param>
         void OverrideWithTestResourceFile(byte[] customResourceFile);
+
+        /// <summary>
+        /// Sets a value indicating whether the application should always use English for the GUI.
+        /// </summary>
+        /// <param name="alwaysEnglish">Pass true to force the application to use English regardless
+        /// of the OS language, false to allow localization.</param>
+        void SetAlwaysEnglish(bool alwaysEnglish);
     }
 }

--- a/src/SilentNotes.AllPlatforms/Services/LanguageService.cs
+++ b/src/SilentNotes.AllPlatforms/Services/LanguageService.cs
@@ -24,6 +24,7 @@ namespace SilentNotes.Services
         private readonly string _languageCode;
         private readonly string _fallbackLanguageCode;
         private Dictionary<string, string> _textResources;
+        private bool _alwaysEnglish;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LanguageService"/> class.
@@ -47,6 +48,7 @@ namespace SilentNotes.Services
             _domain = domain;
             _languageCode = languageCode;
             _fallbackLanguageCode = fallbackLanguageCode;
+            _alwaysEnglish = false;
         }
 
         /// <inheritdoc/>
@@ -121,6 +123,9 @@ namespace SilentNotes.Services
         private Dictionary<string, string> LoadTextResources(string domain, string languageCode)
         {
             Dictionary<string, string> result = null;
+
+            if (_alwaysEnglish)
+                languageCode = "en";
 
             Stream resourceStream = Task.Run(async () => await _resourceReader.TryOpenResourceStream(domain, languageCode)).Result;
             if (resourceStream != null)
@@ -235,6 +240,16 @@ namespace SilentNotes.Services
                         }
                     }
                 }
+            }
+        }
+
+        /// <inheritdoc/>
+        public void SetAlwaysEnglish(bool alwaysEnglish)
+        {
+            if (alwaysEnglish != _alwaysEnglish)
+            {
+                _alwaysEnglish = alwaysEnglish;
+                _textResources = null;
             }
         }
     }

--- a/src/SilentNotes.AllPlatforms/Services/NotificationService.cs
+++ b/src/SilentNotes.AllPlatforms/Services/NotificationService.cs
@@ -39,7 +39,7 @@ namespace SilentNotes.Services
                 new Notification
                 {
                     Id = TransferCodeNotificationId,
-                    Message = _languageService.LoadTextFmt("transfer_code_notification", _languageService.LoadText("show_transfer_code")),
+                    GetMessage = () => _languageService.LoadTextFmt("transfer_code_notification", _languageService.LoadText("show_transfer_code")),
                     QueueTime = TimeSpan.FromDays(5),
                 }
             };
@@ -65,7 +65,7 @@ namespace SilentNotes.Services
                 {
                     trigger.ShownAt = now;
                     _settingsService.TrySaveSettingsToLocalDevice(settings);
-                    await _feedbackService.ShowMessageAsync(notification.Message, string.Empty, MessageBoxButtons.Ok, true);
+                    await _feedbackService.ShowMessageAsync(notification.GetMessage(), string.Empty, MessageBoxButtons.Ok, true);
                     break; // Show only one notification per startup
                 }
             }
@@ -96,8 +96,13 @@ namespace SilentNotes.Services
             /// <summary>Gets or sets the id of the notification.</summary>
             public Guid Id { get; set; }
 
-            /// <summary>Gets or sets the already translated message which of the notification.</summary>
-            public string Message { get; set; }
+            /// <summary>
+            /// Gets a delegate which returns the translated message of the notification.
+            /// </summary>
+            /// <remarks>
+            /// Using a getter we can delay lazy loading of the language resources.
+            /// </remarks>
+            public Func<string> GetMessage { get; set; }
 
             /// <summary>
             /// Gets or sets the timespan to wait until the notification is shown to the

--- a/src/SilentNotes.AllPlatforms/Services/SvgIconService.cs
+++ b/src/SilentNotes.AllPlatforms/Services/SvgIconService.cs
@@ -117,6 +117,7 @@ namespace SilentNotes.Services
                 { IconNames.TagOffOutline, "<svg width='24' height='24' viewBox='0 0 24 24'><path d='M6.5 5A1.5 1.5 0 1 0 8 6.5A1.5 1.5 0 0 0 6.5 5M6.5 5A1.5 1.5 0 1 0 8 6.5A1.5 1.5 0 0 0 6.5 5M18.33 8.5L22.92 3.92L21.5 2.5L2.5 21.5L3.92 22.92L8.5 18.33L11.59 21.42A2 2 0 0 0 13 22A2 2 0 0 0 14.41 21.41L21.41 14.41A2 2 0 0 0 22 13A2 2 0 0 0 21.41 11.58M13 20L9.92 16.92L16.92 9.92L20 13M5.61 15.43L7 14L4 11V4H11L14.06 7.06L15.47 5.66L12.41 2.58A2 2 0 0 0 11 2H4A2 2 0 0 0 2 4V11A2 2 0 0 0 2.59 12.42M5 6.5A1.5 1.5 0 1 0 6.5 5A1.5 1.5 0 0 0 5 6.5Z' /></svg>" },
                 { IconNames.TagOutline, "<svg width='24' height='24' viewBox='0 0 24 24'><path d='M21.41 11.58L12.41 2.58A2 2 0 0 0 11 2H4A2 2 0 0 0 2 4V11A2 2 0 0 0 2.59 12.42L11.59 21.42A2 2 0 0 0 13 22A2 2 0 0 0 14.41 21.41L21.41 14.41A2 2 0 0 0 22 13A2 2 0 0 0 21.41 11.58M13 20L4 11V4H11L20 13M6.5 5A1.5 1.5 0 1 1 5 6.5A1.5 1.5 0 0 1 6.5 5Z' /></svg>" },
                 { IconNames.TagPlusOutline, "<svg width='24' height='24' viewBox='0 0 24 24'><path d='M6.5 5A1.5 1.5 0 1 0 8 6.5A1.5 1.5 0 0 0 6.5 5M6.5 5A1.5 1.5 0 1 0 8 6.5A1.5 1.5 0 0 0 6.5 5M21.41 11.58L12.41 2.58A2 2 0 0 0 11 2H4A2 2 0 0 0 2 4V11A2 2 0 0 0 2.59 12.42L3 12.82A5.62 5.62 0 0 1 5.08 12.08L4 11V4H11L20 13L13 20L11.92 18.92A5.57 5.57 0 0 1 11.18 21L11.59 21.41A2 2 0 0 0 13 22A2 2 0 0 0 14.41 21.41L21.41 14.41A2 2 0 0 0 22 13A2 2 0 0 0 21.41 11.58M6.5 5A1.5 1.5 0 1 0 8 6.5A1.5 1.5 0 0 0 6.5 5M10 19H7V22H5V19H2V17H5V14H7V17H10Z' /></svg>" },
+                { IconNames.Translate, "<svg width='24' height='24' viewBox='0 0 24 24'><path d='M12.87,15.07L10.33,12.56L10.36,12.53C12.1,10.59 13.34,8.36 14.07,6H17V4H10V2H8V4H1V6H12.17C11.5,7.92 10.44,9.75 9,11.35C8.07,10.32 7.3,9.19 6.69,8H4.69C5.42,9.63 6.42,11.17 7.67,12.56L2.58,17.58L4,19L9,14L12.11,17.11L12.87,15.07M18.5,10H16.5L12,22H14L15.12,19H19.87L21,22H23L18.5,10M15.88,17L17.5,12.67L19.12,17H15.88Z' /></svg>" },
                 { IconNames.Undo, "<svg width='24' height='24' viewBox='0 0 24 24'><path d='M12.5,8C9.85,8 7.45,9 5.6,10.6L2,7V16H11L7.38,12.38C8.77,11.22 10.54,10.5 12.5,10.5C16.04,10.5 19.05,12.81 20.1,16L22.47,15.22C21.08,11.03 17.15,8 12.5,8Z' /></svg>" },
                 { IconNames.Wrap, "<svg width='24' height='24' viewBox='0 0 24 24'><path d='M21,5H3V7H21V5M3,19H10V17H3V19M3,13H18C19,13 20,13.43 20,15C20,16.57 19,17 18,17H16V15L12,18L16,21V19H18C20.95,19 22,17.73 22,15C22,12.28 21,11 18,11H3V13Z' /></svg>" },            };
         }
@@ -275,6 +276,7 @@ namespace SilentNotes.Services
         public const string TagOffOutline = "tag-off-outline";
         public const string TagOutline = "tag-outline";
         public const string TagPlusOutline = "tag-plus-outline";
+        public const string Translate = "translate";
         public const string Undo = "undo";
         public const string Wrap = "wrap";
     }

--- a/src/SilentNotes.AllPlatforms/ViewModels/SettingsViewModel.cs
+++ b/src/SilentNotes.AllPlatforms/ViewModels/SettingsViewModel.cs
@@ -126,6 +126,7 @@ namespace SilentNotes.ViewModels
                 string.GetHashCode(settings.SelectedKdfAlgorithm),
                 settings.AutoSyncMode.GetHashCode(),
                 settings.PreventScreenshots.GetHashCode(),
+                settings.AlwaysEnglish.GetHashCode(),
                 (settings.Credentials == null).GetHashCode(),
             });
         }
@@ -443,6 +444,23 @@ namespace SilentNotes.ViewModels
                 {
                     if (_environmentService.Screenshots != null)
                         _environmentService.Screenshots.PreventScreenshots = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether taking screenshots should be forbidden or allowed.
+        /// </summary>
+        public bool AlwaysEnglish
+        {
+            get { return Model.AlwaysEnglish; }
+
+            set
+            {
+                if (SetProperty(Model.AlwaysEnglish, value, (v) => Model.AlwaysEnglish = v))
+                {
+                    (Language as ILanguageTestService)?.SetAlwaysEnglish(Model.AlwaysEnglish);
+                    _messengerService.Send(new RedrawMainPageMessage());
                 }
             }
         }

--- a/src/SilentNotes.Blazor/Directory.Build.props
+++ b/src/SilentNotes.Blazor/Directory.Build.props
@@ -4,7 +4,7 @@
         Here we can define solution wide defines for conditional compiling. Write them semikolon
         delimited after $(DefineConstants) like this...
         
-          $(DefineConstants);FORCE_LANG_EN;FORCE_REPO_DEMO;FORCE_WINDOW_SIZE
+          $(DefineConstants);FORCE_REPO_DEMO;FORCE_WINDOW_SIZE
         
         ...but don't forget to reset this file before building for production. After changing a
         value, please rebuild the solution. Remove DEMO to run unit tests.
@@ -13,7 +13,6 @@
         otherwise it uses an alternative name to keep the original repo intact, see also NoteRepositoryModel.RepositoryFileName
         
         Known defines are:
-        FORCE_LANG_EN:     Enforces an english localization (works only in DEBUG mode)
         FORCE_REPO_DEMO:   Loads hard coded demo data (works only in DEBUG mode)
         FORCE_WINDOW_SIZE: Fixes the size of the main window, so screenshots can be taken (works only in DEBUG mode)
         -->

--- a/src/SilentNotes.Blazor/MauiProgram.cs
+++ b/src/SilentNotes.Blazor/MauiProgram.cs
@@ -94,7 +94,8 @@ public static class MauiProgram
 
         services.AddSingleton<IMessengerService>((serviceProvider) => new MessengerService());
         services.AddSingleton<ISvgIconService>((serviceProvider) => new SvgIconService());
-        services.AddSingleton<ILanguageService>((serviceProvider) => new LanguageService(new LanguageServiceResourceReader(), "SilentNotes", GetLanguageCode()));
+        services.AddSingleton<ILanguageService>((serviceProvider) => new LanguageService(
+            new LanguageServiceResourceReader(), "SilentNotes", new LanguageCodeService().GetSystemLanguageCode()));
         services.AddSingleton<INoteRepositoryUpdater>((serviceProvider) => new NoteRepositoryUpdater());
         services.AddSingleton<IThemeService>((serviceProvider) => new ThemeService(
             serviceProvider.GetService<ISettingsService>(),
@@ -186,13 +187,4 @@ public static class MauiProgram
     }
 
 #endif
-
-    private static string GetLanguageCode()
-    {
-        string languageCode = new LanguageCodeService().GetSystemLanguageCode();
-#if (DEBUG && FORCE_LANG_EN)
-        languageCode = "en";
-#endif
-        return languageCode;
-    }
 }

--- a/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.cz
+++ b/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.cz
@@ -205,4 +205,5 @@ gui_note_insertion_top = Vkládat nové poznámky na začátek
 gui_note_insertion_bottom = Vkládat nové poznámky na konec
 gui_remember_last_tag_filter = Zapamatovat vyhledávání pro další spuštění
 gui_hide_closed_safe_notes = Skrýt poznámky uzamčeného trezoru
+gui_always_english = Always display in English
 gui_localization_test = Vyzkoušet soubor s překladem

--- a/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.de
+++ b/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.de
@@ -205,4 +205,5 @@ gui_note_insertion_top = Neue Notiz oben einfügen
 gui_note_insertion_bottom = Neue Notiz unten anfügen
 gui_remember_last_tag_filter = Schlagwortsuche für nächsten Start merken
 gui_hide_closed_safe_notes = Notizen von geschlossenem Tresor ausblenden
+gui_always_english = Immer auf Englisch anzeigen
 gui_localization_test = Neue Sprachdatei testen

--- a/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.en
+++ b/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.en
@@ -205,4 +205,5 @@ gui_note_insertion_top = Insert new notes at the top
 gui_note_insertion_bottom = Append new notes at the bottom
 gui_remember_last_tag_filter = Remember search tag for next launch
 gui_hide_closed_safe_notes = Hide notes of closed safe
+gui_always_english = Always display in English
 gui_localization_test = Test new language file

--- a/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.hu
+++ b/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.hu
@@ -205,4 +205,5 @@ gui_note_insertion_top = Új jegyzetek beszúrása felül
 gui_note_insertion_bottom = Új jegyzetek hozzáadása alul
 gui_remember_last_tag_filter = Keresési címke megjegyzése a következő indításhoz
 gui_hide_closed_safe_notes = A bezárt széf jegyzeteinek elrejtése
+gui_always_english = Always display in English
 gui_localization_test = Új nyelvi fájl tesztelése

--- a/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.it
+++ b/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.it
@@ -205,4 +205,5 @@ gui_note_insertion_top = Inserisci i nuovi appunti in cima
 gui_note_insertion_bottom = Colloca i nuovi appunti in fondo
 gui_remember_last_tag_filter = Ricorda la ricerca delle etichette per il prossimo avvio
 gui_hide_closed_safe_notes = Nascondi gli appunti della cassaforte chiusa
+gui_always_english = Always display in English
 gui_localization_test = Prova il nuovo file della lingua

--- a/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.ru
+++ b/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.ru
@@ -205,4 +205,5 @@ gui_note_insertion_top = Вставлять новые заметки вверх
 gui_note_insertion_bottom = Добавлять новые заметки внизу
 gui_remember_last_tag_filter = Remember search tag for next launch
 gui_hide_closed_safe_notes = Скрыть заметки закрытого сейфа
+gui_always_english = Always display in English
 gui_localization_test = Тестировать новый языковой файл

--- a/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.tr
+++ b/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.tr
@@ -205,4 +205,5 @@ gui_note_insertion_top = Yeni notları en üste yerleştir
 gui_note_insertion_bottom = Yeni notları en alta yerleştir
 gui_remember_last_tag_filter = Uygulamayı bir sonraki başlatışımda arama etiketini hatırla
 gui_hide_closed_safe_notes = Kasa kilitlenince korunan notları gizle
+gui_always_english = Always display in English
 gui_localization_test = Yeni bir dil dosyasını dene

--- a/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.zh
+++ b/src/SilentNotes.Blazor/Resources/Raw/Localization/Lng.SilentNotes.zh
@@ -205,4 +205,5 @@ gui_note_insertion_top = 在顶部插入新笔记
 gui_note_insertion_bottom = 在底部附加新笔记
 gui_remember_last_tag_filter = 下次启动时记住筛选标签
 gui_hide_closed_safe_notes = 保险箱关闭时隐藏其中的笔记
+gui_always_english = Always display in English
 gui_localization_test = 测试新的语言文件

--- a/src/SilentNotes.Blazor/Views/MainLayout.razor
+++ b/src/SilentNotes.Blazor/Views/MainLayout.razor
@@ -1,5 +1,6 @@
 ﻿@inherits LayoutComponentBase
 
+@using SilentNotes.Models
 @using SilentNotes.ViewModels
 @using SilentNotes.Services
 @using SilentNotes.Workers
@@ -15,6 +16,8 @@
 @inject IMessengerService MessengerService
 @inject ISynchronizationService SynchronizationService
 @inject ISynchronizationState SynchronizationState
+@inject ISettingsService SettingsService
+@inject ILanguageService LanguageService
 
 @implements IDisposable
 
@@ -83,6 +86,10 @@
 		// Give other services a way to redraw the GUI of the whole app.
 		MessengerService.Register<RedrawMainPageMessage>(
 			this, (recipient, message) => InvokeAsync(StateHasChanged));
+
+		SettingsModel settings = SettingsService.LoadSettingsOrDefault();
+		if (settings.AlwaysEnglish)
+			(LanguageService as ILanguageTestService)?.SetAlwaysEnglish(true);
 
 		// Workaround: Scoped services are always correct when injected, but when adding them to
 		// Ioc as scoped services, it seems they get lost, and when demanded the next time the Ioc

--- a/src/SilentNotes.Blazor/Views/SettingsPage.razor
+++ b/src/SilentNotes.Blazor/Views/SettingsPage.razor
@@ -64,8 +64,11 @@
 			<MudIconButton Icon="@Icons.Material.Filled.MoreVert" Color="Color.Inherit" Edge="Edge.End" />
 		</ActivatorContent>
 		<ChildContent>
+			<MudMenuItem OnClick="@(() => ViewModel.AlwaysEnglish = !ViewModel.AlwaysEnglish)"
+				Class="@Css.BuildClass(new CssClassIf(CssClasses.MenuToggled, ViewModel.AlwaysEnglish))"
+				Icon="@IconService[IconNames.Earth]">@LanguageService["gui_always_english"]</MudMenuItem>
 			<MudMenuItem OnClick="@(() => ViewModel.TestNewLocalizationCommand.Execute(null))"
-				Icon="@IconService[IconNames.Earth]">@LanguageService["gui_localization_test"]</MudMenuItem>
+				Icon="@IconService[IconNames.Translate]">@LanguageService["gui_localization_test"]</MudMenuItem>
 		</ChildContent>
 	</MudMenu>
 </MudAppBar>

--- a/src/Tests/SilentNotesTest/Services/LanguageServiceTest.cs
+++ b/src/Tests/SilentNotesTest/Services/LanguageServiceTest.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using SilentNotes.Services;
 
 namespace SilentNotesTest.Services
@@ -127,6 +128,56 @@ namespace SilentNotesTest.Services
             Assert.AreEqual("===", resDictionary["key6"]);
             Assert.AreEqual("Please no", resDictionary["key 7"]);
             Assert.AreEqual(string.Empty, resDictionary["key8"]);
+        }
+
+        [TestMethod]
+        public void LoadText_UsesLazyLoading()
+        {
+            List<string> resFile = new List<string>()
+            {
+                "key1=First text",
+            };
+
+            using (Stream stream = CreateStreamFromLines(resFile))
+            {
+                Mock<ILanguageServiceResourceReader> reader = new Mock<ILanguageServiceResourceReader>();
+                reader
+                    .Setup(m => m.TryOpenResourceStream(It.IsAny<string>(), It.IsAny<string>()))
+                    .ReturnsAsync(stream);
+
+                LanguageService languages = new LanguageService(reader.Object, string.Empty, "de");
+                reader.Verify(m => m.TryOpenResourceStream(It.IsAny<string>(), It.Is<string>(v => v == "de")), Times.Never);
+
+                // First time language resource is loaded, read the stream
+                string localizedText = languages.LoadText("key1");
+                reader.Verify(m => m.TryOpenResourceStream(It.IsAny<string>(), It.Is<string>(v => v == "de")), Times.Once);
+                Assert.AreEqual("First text", localizedText);
+            }
+        }
+
+        [TestMethod]
+        public void SetsAlwaysEnglish_ResetsLazyLoading()
+        {
+            List<string> resFile = new List<string>()
+            {
+                "key1=First text",
+            };
+
+            Mock<ILanguageServiceResourceReader> reader = new Mock<ILanguageServiceResourceReader>();
+            reader
+                .Setup(m => m.TryOpenResourceStream(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(() => CreateStreamFromLines(resFile));
+
+            LanguageService languages = new LanguageService(reader.Object, string.Empty, "de");
+            languages.LoadText("key1");
+            languages.LoadText("key1");
+
+            // Should read the resources again
+            (languages as ILanguageTestService).SetAlwaysEnglish(true);
+            languages.LoadText("key1");
+
+            reader.Verify(m => m.TryOpenResourceStream(It.IsAny<string>(), It.Is<string>(v => v == "de")), Times.Once);
+            reader.Verify(m => m.TryOpenResourceStream(It.IsAny<string>(), It.Is<string>(v => v == "en")), Times.Once);
         }
 
         private Stream CreateStreamFromLines(List<string> lines)


### PR DESCRIPTION
# Description

Added feature to show English UI, regardless of the OS language.

# Checklist:

In the [contribution guidelines](https://github.com/martinstoeckli/SilentNotes/blob/main/CONTRIBUTING.md) you can find more detailed instructions.

- [x] I have added unit-tests, whenever this is possible with a reasonable amount of work
- [x] My code follows the style guidelines of this project (StyleCop rules)
- [x] I have commented all public functions
- [x] I have made corresponding changes to the localization files
