### PR TITLE
Fixed missing storage of moves in/out of safe, when closing the safe.

### DIFF
--- a/src/SilentNotes.AllPlatforms/ViewModels/NoteRepositoryViewModel.cs
+++ b/src/SilentNotes.AllPlatforms/ViewModels/NoteRepositoryViewModel.cs
@@ -470,6 +470,10 @@ namespace SilentNotes.ViewModels
         private void CloseSafe()
         {
             _keyService.CloseAllSafes();
+
+            // A NavigationReload() won't call for storing of unsaved data, but it is the only way
+            // to refresh the page without recreating the scoped services, see NavigationService.ForceLoadNever
+            //OnStoringUnsavedData();
             _navigationService.NavigateReload();
         }
 

--- a/src/SilentNotes.Blazor/Platforms/Windows/ApplicationEventHandler.cs
+++ b/src/SilentNotes.Blazor/Platforms/Windows/ApplicationEventHandler.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.Maui.Platform;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
 using SilentNotes.Services;
@@ -20,10 +21,46 @@ namespace SilentNotes.Platforms
     /// </summary>
     internal class ApplicationEventHandler
     {
+        private Microsoft.UI.Xaml.Window _window;
+        private bool _isClosing;
+
         internal void OnWindowCreated(Microsoft.UI.Xaml.Window window)
         {
+            _window = window;
             AdjustWindowSizeInDemoMode(window);
             window.VisibilityChanged += OnVisibilityChanged;
+            window.AppWindow.Closing += OnClosing;
+        }
+
+        private async void OnClosing(AppWindow sender, AppWindowClosingEventArgs args)
+        {
+            System.Diagnostics.Debug.WriteLine("*** ApplicationEventHandler.OnClosing()");
+
+            // Prevent closing to do a last synchronization (Maui cannot await OnClosing)
+            args.Cancel = true;
+
+            // If app is already closing and syncing, ignore user clicks to close the app
+            if (_isClosing)
+                return;
+            _isClosing = true;
+            sender.Closing -= OnClosing;
+
+            try
+            {
+                var messenger = Ioc.Instance.GetService<IMessengerService>();
+                messenger.Send(new StoreUnsavedDataMessage(MessageSender.ApplicationEventHandler));
+
+                // We need to wait for the end of the synchronization, otherwise the app exits before
+                // the work is done.
+                var synchronizationService = Ioc.Instance.GetService<ISynchronizationService>();
+                var syncTask = synchronizationService.AutoSynchronizeAtShutdown(Ioc.Instance);
+                await syncTask.WaitAsync(TimeSpan.FromSeconds(6));
+            }
+            finally
+            {
+                // Now close the window, the OnClosing event is unsubscribed now and won't cancel the closing
+                _window.Close();
+            }
         }
 
         private void OnVisibilityChanged(object sender, WindowVisibilityChangedEventArgs args)
@@ -40,13 +77,6 @@ namespace SilentNotes.Platforms
         {
             System.Diagnostics.Debug.WriteLine("*** ApplicationEventHandler.OnClosed()");
             window.VisibilityChanged -= OnVisibilityChanged;
-            var messenger = Ioc.Instance.GetService<IMessengerService>();
-            messenger.Send(new StoreUnsavedDataMessage(MessageSender.ApplicationEventHandler));
-
-            // We need to wait for the end of the synchronization, otherwise the app exits before
-            // the work is done.
-            var synchronizationService = Ioc.Instance.GetService<ISynchronizationService>();
-            Task.Run(() => synchronizationService.AutoSynchronizeAtShutdown(Ioc.Instance)).Wait();
         }
 
         /// <summary>


### PR DESCRIPTION
- Fixed missing storage of moves in/out of safe, when closing the safe.
- Keep app open for synchronization when closing the app (Windows only).

- [ ] I have added unit-tests, whenever this is possible with a reasonable amount of work
- [x] My code follows the style guidelines of this project (StyleCop rules)
- [x] I have commented all public functions
- [ ] I have made corresponding changes to the localization files
